### PR TITLE
Refactor state.rs away from using AccountOwnerPublicKey to EthAddress

### DIFF
--- a/core/application/src/env.rs
+++ b/core/application/src/env.rs
@@ -11,7 +11,7 @@ use draco_interfaces::{
     BlockExecutionResponse,
 };
 use fastcrypto::{secp256k1::Secp256k1PublicKey, traits::EncodeDecodeBase64};
-use fleek_crypto::{AccountOwnerPublicKey, ClientPublicKey, NodePublicKey};
+use fleek_crypto::{AccountOwnerPublicKey, ClientPublicKey, NodePublicKey, EthAddress};
 use hp_float::unsigned::HpUfloat;
 
 use crate::{
@@ -30,8 +30,8 @@ impl Env<UpdatePerm> {
     pub fn new() -> Self {
         let atomo = AtomoBuilder::<DefaultSerdeBackend>::new()
             .with_table::<Metadata, Value>("metadata")
-            .with_table::<AccountOwnerPublicKey, AccountInfo>("account")
-            .with_table::<ClientPublicKey, AccountOwnerPublicKey>("client_keys")
+            .with_table::<EthAddress, AccountInfo>("account")
+            .with_table::<ClientPublicKey, EthAddress>("client_keys")
             .with_table::<NodePublicKey, NodeInfo>("node")
             .with_table::<Epoch, Committee>("committee")
             .with_table::<ServiceId, Service>("service")
@@ -121,7 +121,7 @@ impl Env<UpdatePerm> {
             }
 
             let mut node_table = ctx.get_table::<NodePublicKey, NodeInfo>("node");
-            let mut account_table = ctx.get_table::<AccountOwnerPublicKey, AccountInfo>("account");
+            let mut account_table = ctx.get_table::<EthAddress, AccountInfo>("account");
             let mut service_table = ctx.get_table::<ServiceId, Service>("service");
             let mut param_table = ctx.get_table::<ProtocolParams, u128>("parameter");
             let mut committee_table = ctx.get_table::<Epoch, Committee>("committee");
@@ -135,7 +135,7 @@ impl Env<UpdatePerm> {
                     .into();
             metadata_table.insert(
                 Metadata::ProtocolFundAddress,
-                Value::AccountPublicKey(protocol_fund_address),
+                Value::AccountPublicKey(protocol_fund_address.into()),
             );
 
             let supply_at_genesis: HpUfloat<18> = HpUfloat::from(genesis.supply_at_genesis);
@@ -216,7 +216,7 @@ impl Env<UpdatePerm> {
                     bandwidth_balance: account.bandwidth_balance.into(),
                     nonce: 0,
                 };
-                account_table.insert(public_key, info);
+                account_table.insert(EthAddress::from(public_key), info);
             }
 
             // add commodity prices

--- a/core/application/src/genesis.rs
+++ b/core/application/src/genesis.rs
@@ -105,7 +105,7 @@ impl From<&GenesisCommittee> for NodeInfo {
         };
 
         NodeInfo {
-            owner,
+            owner: owner.into(),
             public_key: public_key.into(),
             network_key: network_key.into(),
             domain,

--- a/core/application/src/query_runner.rs
+++ b/core/application/src/query_runner.rs
@@ -7,7 +7,7 @@ use draco_interfaces::{
         TransactionResponse, UpdateRequest, Value,
     },
 };
-use fleek_crypto::{AccountOwnerPublicKey, ClientPublicKey, NodePublicKey};
+use fleek_crypto::{ClientPublicKey, NodePublicKey, EthAddress};
 use hp_float::unsigned::HpUfloat;
 
 use crate::{
@@ -19,8 +19,8 @@ use crate::{
 pub struct QueryRunner {
     inner: Atomo<QueryPerm>,
     metadata_table: ResolvedTableReference<Metadata, Value>,
-    account_table: ResolvedTableReference<AccountOwnerPublicKey, AccountInfo>,
-    client_table: ResolvedTableReference<ClientPublicKey, AccountOwnerPublicKey>,
+    account_table: ResolvedTableReference<EthAddress, AccountInfo>,
+    client_table: ResolvedTableReference<ClientPublicKey, EthAddress>,
     node_table: ResolvedTableReference<NodePublicKey, NodeInfo>,
     committee_table: ResolvedTableReference<Epoch, Committee>,
     _services_table: ResolvedTableReference<ServiceId, Service>,
@@ -37,8 +37,8 @@ impl QueryRunner {
     pub fn init(atomo: Atomo<QueryPerm>) -> Self {
         Self {
             metadata_table: atomo.resolve::<Metadata, Value>("metadata"),
-            account_table: atomo.resolve::<AccountOwnerPublicKey, AccountInfo>("account"),
-            client_table: atomo.resolve::<ClientPublicKey, AccountOwnerPublicKey>("client_keys"),
+            account_table: atomo.resolve::<EthAddress, AccountInfo>("account"),
+            client_table: atomo.resolve::<ClientPublicKey, EthAddress>("client_keys"),
             node_table: atomo.resolve::<NodePublicKey, NodeInfo>("node"),
             committee_table: atomo.resolve::<Epoch, Committee>("committee"),
             _services_table: atomo.resolve::<ServiceId, Service>("service"),
@@ -58,7 +58,7 @@ impl QueryRunner {
 }
 
 impl SyncQueryRunnerInterface for QueryRunner {
-    fn get_account_balance(&self, account: &AccountOwnerPublicKey) -> u128 {
+    fn get_account_balance(&self, account: &EthAddress) -> u128 {
         self.inner.run(|ctx| {
             self.account_table
                 .get(ctx)
@@ -81,7 +81,7 @@ impl SyncQueryRunnerInterface for QueryRunner {
         })
     }
 
-    fn get_flk_balance(&self, account: &AccountOwnerPublicKey) -> HpUfloat<18> {
+    fn get_flk_balance(&self, account: &EthAddress) -> HpUfloat<18> {
         self.inner.run(|ctx| {
             self.account_table
                 .get(ctx)
@@ -91,7 +91,7 @@ impl SyncQueryRunnerInterface for QueryRunner {
         })
     }
 
-    fn get_stables_balance(&self, account: &AccountOwnerPublicKey) -> HpUfloat<6> {
+    fn get_stables_balance(&self, account: &EthAddress) -> HpUfloat<6> {
         self.inner.run(|ctx| {
             self.account_table
                 .get(ctx)
@@ -267,7 +267,7 @@ impl SyncQueryRunnerInterface for QueryRunner {
         })
     }
 
-    fn get_protocol_fund_address(&self) -> AccountOwnerPublicKey {
+    fn get_protocol_fund_address(&self) -> EthAddress {
         self.inner.run(|ctx| {
             let owner = match self
                 .metadata_table

--- a/core/application/src/state.rs
+++ b/core/application/src/state.rs
@@ -14,8 +14,8 @@ use draco_interfaces::{
 };
 use draco_reputation::{statistics, types::WeightedReputationMeasurements};
 use fleek_crypto::{
-    AccountOwnerPublicKey, ClientPublicKey, NodeNetworkingPublicKey, NodePublicKey,
-    TransactionSender,
+    ClientPublicKey, NodeNetworkingPublicKey, NodePublicKey,
+    TransactionSender, EthAddress,
 };
 use hp_float::unsigned::HpUfloat;
 use multiaddr::Multiaddr;
@@ -50,8 +50,8 @@ const REP_EWMA_WEIGHT: f64 = 0.7;
 /// All state changes come from Transactions and start at execute_txn
 pub struct State<B: Backend> {
     pub metadata: B::Ref<Metadata, Value>,
-    pub account_info: B::Ref<AccountOwnerPublicKey, AccountInfo>,
-    pub client_keys: B::Ref<ClientPublicKey, AccountOwnerPublicKey>,
+    pub account_info: B::Ref<EthAddress, AccountInfo>,
+    pub client_keys: B::Ref<ClientPublicKey, EthAddress>,
     pub node_info: B::Ref<NodePublicKey, NodeInfo>,
     pub committee_info: B::Ref<Epoch, Committee>,
     pub services: B::Ref<ServiceId, Service>,
@@ -246,7 +246,7 @@ impl<B: Backend> State<B> {
     fn withdraw(
         &self,
         _sender: TransactionSender,
-        _reciever: AccountOwnerPublicKey,
+        _reciever: EthAddress,
         _amount: HpUfloat<18>,
         _token: Tokens,
     ) -> TransactionResponse {
@@ -444,7 +444,7 @@ impl<B: Backend> State<B> {
         };
 
         // Make sure the caller is the owner of the node
-        if node.owner != sender {
+        if sender != node.owner.into() {
             return TransactionResponse::Revert(ExecutionError::NotNodeOwner);
         }
         // check if node has stakes to be locked
@@ -494,7 +494,7 @@ impl<B: Backend> State<B> {
         };
 
         // Make sure the caller is the owner of the node
-        if node.owner != sender {
+        if sender != node.owner.into() {
             return TransactionResponse::Revert(ExecutionError::NotNodeOwner);
         }
 
@@ -531,7 +531,7 @@ impl<B: Backend> State<B> {
         &self,
         sender: TransactionSender,
         node_public_key: NodePublicKey,
-        recipient: Option<AccountOwnerPublicKey>,
+        recipient: Option<EthAddress>,
     ) -> TransactionResponse {
         // This transaction is only callable by AccountOwners and not nodes
         // So revert if the sender is a node public key
@@ -546,7 +546,7 @@ impl<B: Backend> State<B> {
         };
 
         // Make sure the caller is the owner of the node
-        if node.owner != sender_public_key {
+        if sender_public_key != node.owner.into() {
             return TransactionResponse::Revert(ExecutionError::NotNodeOwner);
         }
 
@@ -564,7 +564,7 @@ impl<B: Backend> State<B> {
 
         // if there is no recipient the owner will recieve the withdrawl
         let recipient = recipient.unwrap_or(sender_public_key);
-        let mut reciever = self.account_info.get(&recipient).unwrap_or_default();
+        let mut reciever = self.account_info.get(&recipient.into()).unwrap_or_default();
 
         // add the withdrawn tokens to the recipient and reset the nodes locked stake state
         // no need to reset locked_until on the node because that will get adjusted the next time
@@ -576,7 +576,7 @@ impl<B: Backend> State<B> {
         // state tables completly?
 
         // Save state changes and return response
-        self.account_info.set(recipient, reciever);
+        self.account_info.set(recipient.into(), reciever);
         self.node_info.set(node_public_key, node);
         TransactionResponse::Success(ExecutionData::None)
     }
@@ -907,18 +907,18 @@ impl<B: Backend> State<B> {
         (max_emissions, min_emissions)
     }
 
-    fn mint_and_transfer_stables(&self, amount: HpUfloat<6>, owner: AccountOwnerPublicKey) {
-        let mut account = self.account_info.get(&owner).unwrap_or_default();
+    fn mint_and_transfer_stables(&self, amount: HpUfloat<6>, owner: EthAddress) {
+        let mut account = self.account_info.get(&owner.into()).unwrap_or_default();
 
         account.stables_balance += amount;
         self.account_info.set(owner, account);
     }
 
-    fn mint_and_transfer_flk(&self, amount: HpUfloat<18>, owner: AccountOwnerPublicKey) {
-        let mut account = self.account_info.get(&owner).unwrap_or_default();
+    fn mint_and_transfer_flk(&self, amount: HpUfloat<18>, owner: EthAddress) {
+        let mut account = self.account_info.get(&owner.into()).unwrap_or_default();
         account.flk_balance += amount.clone();
 
-        self.account_info.set(owner, account);
+        self.account_info.set(owner.into(), account);
 
         let mut current_supply = match self.metadata.get(&Metadata::TotalSupply) {
             Some(Value::HpUfloat(supply)) => supply,
@@ -1004,9 +1004,9 @@ impl<B: Backend> State<B> {
                 self.node_info.set(node, node_info);
             },
             TransactionSender::AccountOwner(account) => {
-                let mut account_info = self.account_info.get(&account).unwrap();
+                let mut account_info = self.account_info.get(&account.into()).unwrap();
                 account_info.nonce += 1;
-                self.account_info.set(account, account_info);
+                self.account_info.set(account.into(), account_info);
             },
         }
     }
@@ -1015,7 +1015,7 @@ impl<B: Backend> State<B> {
     fn only_account_owner(
         &self,
         sender: TransactionSender,
-    ) -> Result<AccountOwnerPublicKey, TransactionResponse> {
+    ) -> Result<EthAddress, TransactionResponse> {
         match sender {
             TransactionSender::AccountOwner(account) => Ok(account),
             _ => Err(TransactionResponse::Revert(

--- a/core/application/src/table.rs
+++ b/core/application/src/table.rs
@@ -4,7 +4,7 @@ use atomo::{KeyIterator, SerdeBackend, TableRef as AtomoTableRef, TableSelector}
 use draco_interfaces::types::{
     ExecutionError, ProofOfConsensus, ProofOfMisbehavior, UpdateRequest,
 };
-use fleek_crypto::{AccountOwnerPublicKey, NodePublicKey};
+use fleek_crypto::{NodePublicKey, EthAddress};
 use serde::{de::DeserializeOwned, Serialize};
 
 pub trait Backend {
@@ -25,7 +25,7 @@ pub trait Backend {
     /// Takes in a zk Proof Of Delivery and returns true if valid
     fn verify_proof_of_delivery(
         &self,
-        client: &AccountOwnerPublicKey,
+        client: &EthAddress,
         provider: &NodePublicKey,
         commodity: &u128,
         service_id: &u32,
@@ -70,7 +70,7 @@ impl<'selector, S: SerdeBackend> Backend for StateTables<'selector, S> {
 
     fn verify_proof_of_delivery(
         &self,
-        _client: &AccountOwnerPublicKey,
+        _client: &EthAddress,
         _provider: &NodePublicKey,
         _commodity: &u128,
         _service_id: &u32,

--- a/core/interfaces/src/application.rs
+++ b/core/interfaces/src/application.rs
@@ -1,6 +1,6 @@
 use affair::Socket;
 use async_trait::async_trait;
-use fleek_crypto::{AccountOwnerPublicKey, ClientPublicKey, NodePublicKey};
+use fleek_crypto::{ClientPublicKey, NodePublicKey, EthAddress};
 use hp_float::unsigned::HpUfloat;
 
 use crate::{
@@ -71,16 +71,16 @@ pub trait ApplicationInterface:
 
 pub trait SyncQueryRunnerInterface: Clone + Send + Sync + 'static {
     /// Returns the latest bandwidth balance associated with the given account public key.
-    fn get_account_balance(&self, account: &AccountOwnerPublicKey) -> u128;
+    fn get_account_balance(&self, account: &EthAddress) -> u128;
 
     /// Returns the latest bandwidth balance associated with the given client public key.
     fn get_client_balance(&self, client: &ClientPublicKey) -> u128;
 
     /// Returns the latest FLK balance of an account
-    fn get_flk_balance(&self, account: &AccountOwnerPublicKey) -> HpUfloat<18>;
+    fn get_flk_balance(&self, account: &EthAddress) -> HpUfloat<18>;
 
     /// Returns the latest stables balance of an account
-    fn get_stables_balance(&self, account: &AccountOwnerPublicKey) -> HpUfloat<6>;
+    fn get_stables_balance(&self, account: &EthAddress) -> HpUfloat<6>;
 
     /// Returns the amount of flk a node has staked
     fn get_staked(&self, node: &NodePublicKey) -> HpUfloat<18>;
@@ -146,7 +146,7 @@ pub trait SyncQueryRunnerInterface: Clone + Send + Sync + 'static {
     fn get_year_start_supply(&self) -> HpUfloat<18>;
 
     /// Return the foundation address where protocol fund goes to
-    fn get_protocol_fund_address(&self) -> AccountOwnerPublicKey;
+    fn get_protocol_fund_address(&self) -> EthAddress;
 
     /// Returns the passed in protocol parameter
     fn get_protocol_params(&self, param: ProtocolParams) -> u128;

--- a/core/interfaces/src/types.rs
+++ b/core/interfaces/src/types.rs
@@ -1,8 +1,8 @@
 use std::{collections::BTreeMap, time::Duration};
 
 use fleek_crypto::{
-    AccountOwnerPublicKey, NodeNetworkingPublicKey, NodePublicKey, TransactionSender,
-    TransactionSignature,
+    NodeNetworkingPublicKey, NodePublicKey, TransactionSender,
+    TransactionSignature, EthAddress,
 };
 use hp_float::unsigned::HpUfloat;
 use multiaddr::Multiaddr;
@@ -44,7 +44,7 @@ pub enum Value {
     Epoch(u64),
     String(String),
     HpUfloat(HpUfloat<18>),
-    AccountPublicKey(AccountOwnerPublicKey),
+    AccountPublicKey(EthAddress),
 }
 
 /// This is commodities served by different services in Fleek Network.
@@ -120,7 +120,7 @@ pub enum UpdateMethod {
         /// Which token to withdrawl
         token: Tokens,
         /// The address to recieve these tokens on the L2
-        receiving_address: AccountOwnerPublicKey,
+        receiving_address: EthAddress,
     },
     /// Submit of PoC from the bridge on the L2 to get the tokens in network
     Deposit {
@@ -165,7 +165,7 @@ pub enum UpdateMethod {
     /// recieve the tokens
     WithdrawUnstaked {
         node: NodePublicKey,
-        recipient: Option<AccountOwnerPublicKey>,
+        recipient: Option<EthAddress>,
     },
     /// Sent by committee member to signal he is ready to change epoch
     ChangeEpoch { epoch: Epoch },
@@ -264,7 +264,7 @@ pub struct Staking {
 #[derive(Debug, Hash, PartialEq, PartialOrd, Ord, Eq, Serialize, Deserialize, Clone)]
 pub struct NodeInfo {
     /// The owner of this node
-    pub owner: AccountOwnerPublicKey,
+    pub owner: EthAddress,
     /// The BLS public key of the node which is used for our BFT DAG consensus
     /// multi signatures.
     pub public_key: NodePublicKey,

--- a/core/rpc/src/handlers.rs
+++ b/core/rpc/src/handlers.rs
@@ -48,7 +48,7 @@ pub async fn get_balance_handler<Q: SyncQueryRunnerInterface, I: RpcInterface<Q>
     data: Data<Arc<I>>,
     Params(params): Params<PublicKeyParam>,
 ) -> Result<HpUfloat<18>> {
-    Ok(data.0.query_runner().get_flk_balance(&params.public_key))
+    Ok(data.0.query_runner().get_flk_balance(&params.public_key.into()))
 }
 
 pub async fn get_bandwidth_balance_handler<Q: SyncQueryRunnerInterface, I: RpcInterface<Q>>(
@@ -58,7 +58,7 @@ pub async fn get_bandwidth_balance_handler<Q: SyncQueryRunnerInterface, I: RpcIn
     Ok(data
         .0
         .query_runner()
-        .get_account_balance(&params.public_key))
+        .get_account_balance(&params.public_key.into()))
 }
 
 pub async fn get_locked_handler<Q: SyncQueryRunnerInterface, I: RpcInterface<Q>>(


### PR DESCRIPTION
Temporary branch: This creates a tuple struct representing a Ethereum Address in fleek crypto lib and replaces the usage of AccountOwnerPublicKey in state.rs in the core application.