### PR TITLE
Fix "responce" typo

### DIFF
--- a/core/cli/src/commands/opt.rs
+++ b/core/cli/src/commands/opt.rs
@@ -353,7 +353,7 @@ pub async fn query_genesis_committee<T: DeserializeOwned>(
         .collect();
 
     if results.is_empty() {
-        Err(anyhow!("Unable to get a responce from nodes"))
+        Err(anyhow!("Unable to get a response from nodes"))
     } else {
         Ok(results)
     }

--- a/core/syncronizer/src/rpc.rs
+++ b/core/syncronizer/src/rpc.rs
@@ -56,7 +56,7 @@ pub async fn ask_nodes<T: DeserializeOwned>(
         .collect();
 
     if results.is_empty() {
-        Err(anyhow!("Unable to get a responce from nodes"))
+        Err(anyhow!("Unable to get a response from nodes"))
     } else {
         Ok(results)
     }


### PR DESCRIPTION
While playing with the repo/node I noticed a typo in some error output ("responce"), so this PR updates those references to "response".