### PR TITLE
feat: add command to SDK to query the SGX public key

### DIFF
--- a/core/service-executor/src/service.rs
+++ b/core/service-executor/src/service.rs
@@ -8,6 +8,7 @@ use fleek_crypto::{ClientPublicKey, NodePublicKey};
 use fn_sdk::ipc_types::{self, IpcMessage, IpcRequest, Response, DELIMITER_SIZE};
 use lightning_interfaces::prelude::*;
 use lightning_interfaces::schema::task_broker::TaskScope;
+use lightning_interfaces::types::{ProtocolParamKey, ProtocolParamValue};
 use lightning_utils::application::QueryRunnerExt;
 use rand::seq::SliceRandom;
 use rand::thread_rng;
@@ -139,6 +140,17 @@ impl<C: Collection> Context<C> {
             ipc_types::Request::FetchNodeIndex {} => {
                 let node_index = self.query_runner.pubkey_to_index(&self.our_public_key);
                 ipc_types::Response::FetchNodeIndex { node_index }
+            },
+            ipc_types::Request::FetchSgxSharedPubKey {} => {
+                match self
+                    .query_runner
+                    .get_protocol_param(&ProtocolParamKey::SGXSharedPubKey)
+                {
+                    Some(ProtocolParamValue::SGXSharedPubKey(public_key)) => {
+                        ipc_types::Response::FetchSgxSharedPubKey { public_key }
+                    },
+                    _ => unreachable!(), // added in the genesis
+                }
             },
             _ => unreachable!(),
         }

--- a/lib/sdk/src/api.rs
+++ b/lib/sdk/src/api.rs
@@ -68,6 +68,15 @@ pub async fn fetch_node_index() -> Option<u32> {
     }
 }
 
+pub async fn fetch_sgx_shared_pub_key() -> String {
+    let req = Request::FetchSgxSharedPubKey {};
+    let res = send_and_await_response(req).await;
+    match res {
+        crate::ipc_types::Response::FetchSgxSharedPubKey { public_key } => public_key,
+        _ => unreachable!(),
+    }
+}
+
 pub async fn run_task(
     depth: u8,
     scope: TaskScope,

--- a/lib/sdk/src/ipc_types.rs
+++ b/lib/sdk/src/ipc_types.rs
@@ -212,6 +212,11 @@ ReqRes! {
         /// The node index of this node
         node_index: Option<u32>,
     },
+    FetchSgxSharedPubKey {
+        =>
+        /// The node index of this node
+        public_key: String,
+    },
     /// Submit a task
     Task {
         depth: u8,


### PR DESCRIPTION
We need to query the SGX shared public key from the state in the SGX service, so we have to add this command to the SDK.