### PR TITLE
feat: check enclave public key against public key on state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -993,7 +993,7 @@ dependencies = [
 [[package]]
 name = "atomo"
 version = "0.0.5"
-source = "git+https://github.com/fleek-network/lightning?rev=0.1.0-alpha.3#043f9067d21d5eb5a4bec89e6b3ae881bc392e6e"
+source = "git+https://github.com/fleek-network/lightning?rev=0.1.0-alpha.4#3b21025a5946fda345813453b58ca5c0f6dcb4e4"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -1090,7 +1090,7 @@ dependencies = [
  "serde_path_to_error",
  "serde_urlencoded",
  "sha1",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "tokio",
  "tokio-tungstenite",
  "tower",
@@ -1125,7 +1125,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "tokio",
  "tower",
  "tower-layer",
@@ -1165,7 +1165,7 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1673,7 +1673,7 @@ dependencies = [
 [[package]]
 name = "blake3-tree"
 version = "0.1.0"
-source = "git+https://github.com/fleek-network/lightning?rev=0.1.0-alpha.3#043f9067d21d5eb5a4bec89e6b3ae881bc392e6e"
+source = "git+https://github.com/fleek-network/lightning?rev=0.1.0-alpha.4#3b21025a5946fda345813453b58ca5c0f6dcb4e4"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -4122,7 +4122,7 @@ dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.36",
  "regex",
- "reqwest",
+ "reqwest 0.11.20",
  "serde",
  "serde_json",
  "syn 2.0.72",
@@ -4184,7 +4184,7 @@ checksum = "e79e5973c26d4baf0ce55520bd732314328cabe53193286671b47144145b9649"
 dependencies = [
  "chrono",
  "ethers-core",
- "reqwest",
+ "reqwest 0.11.20",
  "semver 1.0.23",
  "serde",
  "serde_json",
@@ -4209,7 +4209,7 @@ dependencies = [
  "futures-locks",
  "futures-util",
  "instant",
- "reqwest",
+ "reqwest 0.11.20",
  "serde",
  "serde_json",
  "thiserror",
@@ -4241,7 +4241,7 @@ dependencies = [
  "jsonwebtoken",
  "once_cell",
  "pin-project",
- "reqwest",
+ "reqwest 0.11.20",
  "serde",
  "serde_json",
  "thiserror",
@@ -4348,7 +4348,7 @@ dependencies = [
  "image",
  "lightning-workspace-hack",
  "ndarray",
- "reqwest",
+ "reqwest 0.11.20",
  "safetensors",
  "safetensors-ndarray",
  "tokio",
@@ -4704,7 +4704,7 @@ dependencies = [
 [[package]]
 name = "fleek-crypto"
 version = "0.0.0"
-source = "git+https://github.com/fleek-network/lightning?rev=0.1.0-alpha.3#043f9067d21d5eb5a4bec89e6b3ae881bc392e6e"
+source = "git+https://github.com/fleek-network/lightning?rev=0.1.0-alpha.4#3b21025a5946fda345813453b58ca5c0f6dcb4e4"
 dependencies = [
  "arrayref",
  "derive_more",
@@ -4715,6 +4715,7 @@ dependencies = [
  "sec1",
  "serde",
  "serde-big-array",
+ "thiserror",
  "zeroize",
 ]
 
@@ -4730,7 +4731,7 @@ dependencies = [
  "ipld-core",
  "ipld-dagpb",
  "quick-protobuf",
- "reqwest",
+ "reqwest 0.11.20",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -4829,9 +4830,10 @@ dependencies = [
  "bytes 1.7.1",
  "dcap-quoteprov",
  "enclave-runner",
- "fn-sdk 0.0.0 (git+https://github.com/fleek-network/lightning?rev=0.1.0-alpha.3)",
+ "fn-sdk 0.0.0 (git+https://github.com/fleek-network/lightning?rev=0.1.0-alpha.4)",
  "futures 0.3.30",
  "hex",
+ "reqwest 0.12.7",
  "serde",
  "serde-big-array",
  "serde_cbor",
@@ -4911,16 +4913,16 @@ dependencies = [
 [[package]]
 name = "fn-sdk"
 version = "0.0.0"
-source = "git+https://github.com/fleek-network/lightning?rev=0.1.0-alpha.3#043f9067d21d5eb5a4bec89e6b3ae881bc392e6e"
+source = "git+https://github.com/fleek-network/lightning?rev=0.1.0-alpha.4#3b21025a5946fda345813453b58ca5c0f6dcb4e4"
 dependencies = [
  "anyhow",
  "arrayvec",
- "blake3-tree 0.1.0 (git+https://github.com/fleek-network/lightning?rev=0.1.0-alpha.3)",
+ "blake3-tree 0.1.0 (git+https://github.com/fleek-network/lightning?rev=0.1.0-alpha.4)",
  "bytes 1.7.1",
  "derive_more",
- "fleek-crypto 0.0.0 (git+https://github.com/fleek-network/lightning?rev=0.1.0-alpha.3)",
- "hp-fixed 0.1.0 (git+https://github.com/fleek-network/lightning?rev=0.1.0-alpha.3)",
- "lightning-schema 0.0.0 (git+https://github.com/fleek-network/lightning?rev=0.1.0-alpha.3)",
+ "fleek-crypto 0.0.0 (git+https://github.com/fleek-network/lightning?rev=0.1.0-alpha.4)",
+ "hp-fixed 0.1.0 (git+https://github.com/fleek-network/lightning?rev=0.1.0-alpha.4)",
+ "lightning-schema 0.0.0 (git+https://github.com/fleek-network/lightning?rev=0.1.0-alpha.4)",
  "prctl",
  "ringbuf",
  "rkyv",
@@ -5735,7 +5737,7 @@ dependencies = [
 [[package]]
 name = "hp-fixed"
 version = "0.1.0"
-source = "git+https://github.com/fleek-network/lightning?rev=0.1.0-alpha.3#043f9067d21d5eb5a4bec89e6b3ae881bc392e6e"
+source = "git+https://github.com/fleek-network/lightning?rev=0.1.0-alpha.4#3b21025a5946fda345813453b58ca5c0f6dcb4e4"
 dependencies = [
  "anyhow",
  "num-bigint 0.4.6",
@@ -5987,6 +5989,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes 1.7.1",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6235,7 +6253,7 @@ dependencies = [
 [[package]]
 name = "ink-quill"
 version = "0.1.0"
-source = "git+https://github.com/fleek-network/lightning?rev=0.1.0-alpha.3#043f9067d21d5eb5a4bec89e6b3ae881bc392e6e"
+source = "git+https://github.com/fleek-network/lightning?rev=0.1.0-alpha.4#3b21025a5946fda345813453b58ca5c0f6dcb4e4"
 dependencies = [
  "fleek-blake3",
 ]
@@ -7068,11 +7086,11 @@ dependencies = [
  "lightning-test-utils",
  "lightning-utils",
  "lightning-workspace-hack",
- "merklize",
+ "merklize 0.0.0",
  "multiaddr",
  "num-traits",
  "rand 0.8.5",
- "resolved-pathbuf",
+ "resolved-pathbuf 0.2.0",
  "serde",
  "serde_with 3.9.0",
  "tempfile",
@@ -7098,7 +7116,7 @@ dependencies = [
  "lightning-test-utils",
  "lightning-utils",
  "lightning-workspace-hack",
- "resolved-pathbuf",
+ "resolved-pathbuf 0.2.0",
  "rocksdb",
  "serde",
  "tempfile",
@@ -7121,7 +7139,7 @@ dependencies = [
  "lightning-workspace-hack",
  "parking_lot",
  "rand 0.8.5",
- "resolved-pathbuf",
+ "resolved-pathbuf 0.2.0",
  "serde",
  "thiserror",
  "tokio",
@@ -7228,11 +7246,11 @@ dependencies = [
  "lightning-topology",
  "lightning-utils",
  "lightning-workspace-hack",
- "merklize",
+ "merklize 0.0.0",
  "pretty_assertions",
  "rand 0.8.5",
  "ready",
- "resolved-pathbuf",
+ "resolved-pathbuf 0.2.0",
  "serde",
  "tempfile",
  "thiserror",
@@ -7282,13 +7300,13 @@ dependencies = [
  "lightning-tui",
  "lightning-utils",
  "lightning-workspace-hack",
- "merklize",
+ "merklize 0.0.0",
  "once_cell",
  "os_info",
  "panic-report",
  "rand 0.8.5",
- "reqwest",
- "resolved-pathbuf",
+ "reqwest 0.11.20",
+ "resolved-pathbuf 0.2.0",
  "serde",
  "serde_json",
  "serial_test",
@@ -7334,7 +7352,7 @@ dependencies = [
  "prometheus",
  "quick_cache",
  "rand 0.8.5",
- "resolved-pathbuf",
+ "resolved-pathbuf 0.2.0",
  "serde",
  "sui-protocol-config 0.1.0 (git+https://github.com/MystenLabs/sui.git?rev=bbfaafc17652d221651e835c908028c440f039d7)",
  "tempfile",
@@ -7360,7 +7378,7 @@ dependencies = [
  "lightning-utils",
  "lightning-workspace-hack",
  "queue-file",
- "resolved-pathbuf",
+ "resolved-pathbuf 0.2.0",
  "serde",
  "tempfile",
  "tokio",
@@ -7404,9 +7422,9 @@ dependencies = [
  "lightning-utils",
  "lightning-workspace-hack",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.11.20",
  "resolve-path",
- "resolved-pathbuf",
+ "resolved-pathbuf 0.2.0",
  "serde",
  "serde_json",
  "serial_test",
@@ -7489,7 +7507,7 @@ dependencies = [
  "lightning-topology",
  "lightning-utils",
  "lightning-workspace-hack",
- "resolved-pathbuf",
+ "resolved-pathbuf 0.2.0",
  "toml 0.7.8",
  "tracing",
 ]
@@ -7543,7 +7561,7 @@ dependencies = [
  "log",
  "notify",
  "once_cell",
- "resolved-pathbuf",
+ "resolved-pathbuf 0.2.0",
  "serde",
  "serde_json",
  "tokio",
@@ -7586,7 +7604,7 @@ dependencies = [
  "lightning-workspace-hack",
  "rand 0.8.5",
  "rcgen 0.11.3",
- "resolved-pathbuf",
+ "resolved-pathbuf 0.2.0",
  "ring 0.16.20",
  "serde",
  "serde_json",
@@ -7648,7 +7666,7 @@ dependencies = [
  "lightning-schema 0.0.0",
  "lightning-types 0.1.0",
  "lightning-workspace-hack",
- "merklize",
+ "merklize 0.0.0",
  "ready",
  "schemars",
  "serde",
@@ -7673,7 +7691,7 @@ dependencies = [
  "lightning-test-utils",
  "lightning-utils",
  "lightning-workspace-hack",
- "resolved-pathbuf",
+ "resolved-pathbuf 0.2.0",
  "serde",
  "tokio",
  "tracing",
@@ -7717,7 +7735,7 @@ dependencies = [
  "lightning-interfaces",
  "lightning-utils",
  "lightning-workspace-hack",
- "merklize",
+ "merklize 0.0.0",
  "tokio",
 ]
 
@@ -7805,7 +7823,7 @@ dependencies = [
  "lightning-signer",
  "lightning-test-utils",
  "lightning-workspace-hack",
- "reqwest",
+ "reqwest 0.11.20",
  "serde",
  "tempfile",
  "tokio",
@@ -7968,7 +7986,7 @@ dependencies = [
  "lightning-topology",
  "lightning-utils",
  "lightning-workspace-hack",
- "resolved-pathbuf",
+ "resolved-pathbuf 0.2.0",
  "rocksdb",
  "serde",
  "tempfile",
@@ -8014,13 +8032,13 @@ dependencies = [
  "lightning-types 0.1.0",
  "lightning-utils",
  "lightning-workspace-hack",
- "merklize",
+ "merklize 0.0.0",
  "once_cell",
  "prometheus",
  "rand 0.8.5",
  "ready",
- "reqwest",
- "resolved-pathbuf",
+ "reqwest 0.11.20",
+ "resolved-pathbuf 0.2.0",
  "ruint",
  "serde",
  "serde_json",
@@ -8050,15 +8068,15 @@ dependencies = [
 [[package]]
 name = "lightning-schema"
 version = "0.0.0"
-source = "git+https://github.com/fleek-network/lightning?rev=0.1.0-alpha.3#043f9067d21d5eb5a4bec89e6b3ae881bc392e6e"
+source = "git+https://github.com/fleek-network/lightning?rev=0.1.0-alpha.4#3b21025a5946fda345813453b58ca5c0f6dcb4e4"
 dependencies = [
  "anyhow",
  "arrayref",
  "bytes 1.7.1",
- "fleek-crypto 0.0.0 (git+https://github.com/fleek-network/lightning?rev=0.1.0-alpha.3)",
+ "fleek-crypto 0.0.0 (git+https://github.com/fleek-network/lightning?rev=0.1.0-alpha.4)",
  "flexbuffers",
- "ink-quill 0.1.0 (git+https://github.com/fleek-network/lightning?rev=0.1.0-alpha.3)",
- "lightning-types 0.1.0 (git+https://github.com/fleek-network/lightning?rev=0.1.0-alpha.3)",
+ "ink-quill 0.1.0 (git+https://github.com/fleek-network/lightning?rev=0.1.0-alpha.4)",
+ "lightning-types 0.1.0 (git+https://github.com/fleek-network/lightning?rev=0.1.0-alpha.4)",
  "lightning-workspace-hack",
  "serde",
 ]
@@ -8092,7 +8110,7 @@ dependencies = [
  "lightning-workspace-hack",
  "panic-report",
  "rand 0.8.5",
- "resolved-pathbuf",
+ "resolved-pathbuf 0.2.0",
  "serde",
  "serial_test",
  "tempfile",
@@ -8117,7 +8135,7 @@ dependencies = [
  "lightning-test-utils",
  "lightning-utils",
  "lightning-workspace-hack",
- "resolved-pathbuf",
+ "resolved-pathbuf 0.2.0",
  "serde",
  "tempfile",
  "tokio",
@@ -8139,7 +8157,7 @@ dependencies = [
  "lightning-utils",
  "lightning-workspace-hack",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.11.20",
  "serde",
  "serde_json",
  "tokio",
@@ -8210,14 +8228,14 @@ dependencies = [
  "lightning-topology",
  "lightning-utils",
  "lightning-workspace-hack",
- "merklize",
+ "merklize 0.0.0",
  "plotters",
  "pretty_assertions",
  "rand 0.8.5",
  "rand_chacha",
  "rand_distr",
  "ready",
- "resolved-pathbuf",
+ "resolved-pathbuf 0.2.0",
  "serde",
  "serde_json",
  "simplelog",
@@ -8284,7 +8302,7 @@ dependencies = [
  "lightning-utils",
  "log",
  "ratatui",
- "resolved-pathbuf",
+ "resolved-pathbuf 0.2.0",
  "serde",
  "serde_json",
  "signal-hook",
@@ -8313,12 +8331,12 @@ dependencies = [
  "hp-fixed 0.1.0",
  "ink-quill 0.1.0",
  "lightning-workspace-hack",
- "merklize",
+ "merklize 0.0.0",
  "multiaddr",
  "num-bigint 0.4.6",
  "num-derive 0.4.2",
  "num-traits",
- "resolved-pathbuf",
+ "resolved-pathbuf 0.2.0",
  "ruint",
  "schemars",
  "serde",
@@ -8332,27 +8350,32 @@ dependencies = [
 [[package]]
 name = "lightning-types"
 version = "0.1.0"
-source = "git+https://github.com/fleek-network/lightning?rev=0.1.0-alpha.3#043f9067d21d5eb5a4bec89e6b3ae881bc392e6e"
+source = "git+https://github.com/fleek-network/lightning?rev=0.1.0-alpha.4#3b21025a5946fda345813453b58ca5c0f6dcb4e4"
 dependencies = [
  "anyhow",
- "atomo 0.0.5 (git+https://github.com/fleek-network/lightning?rev=0.1.0-alpha.3)",
+ "atomo 0.0.5 (git+https://github.com/fleek-network/lightning?rev=0.1.0-alpha.4)",
  "bincode",
+ "bit-set 0.8.0",
  "cid 0.10.1",
  "compile-time-run",
  "derive_more",
  "ethers",
- "fleek-crypto 0.0.0 (git+https://github.com/fleek-network/lightning?rev=0.1.0-alpha.3)",
- "hp-fixed 0.1.0 (git+https://github.com/fleek-network/lightning?rev=0.1.0-alpha.3)",
- "ink-quill 0.1.0 (git+https://github.com/fleek-network/lightning?rev=0.1.0-alpha.3)",
+ "fleek-crypto 0.0.0 (git+https://github.com/fleek-network/lightning?rev=0.1.0-alpha.4)",
+ "hp-fixed 0.1.0 (git+https://github.com/fleek-network/lightning?rev=0.1.0-alpha.4)",
+ "ink-quill 0.1.0 (git+https://github.com/fleek-network/lightning?rev=0.1.0-alpha.4)",
  "lightning-workspace-hack",
+ "merklize 0.0.0 (git+https://github.com/fleek-network/lightning?rev=0.1.0-alpha.4)",
  "multiaddr",
  "num-bigint 0.4.6",
  "num-derive 0.4.2",
  "num-traits",
+ "resolved-pathbuf 0.2.0 (git+https://github.com/fleek-network/lightning?rev=0.1.0-alpha.4)",
  "ruint",
  "schemars",
  "serde",
+ "serde_with 3.9.0",
  "thiserror",
+ "toml 0.7.8",
  "url",
 ]
 
@@ -8366,8 +8389,8 @@ dependencies = [
  "lazy_static",
  "lightning-interfaces",
  "lightning-workspace-hack",
- "reqwest",
- "resolved-pathbuf",
+ "reqwest 0.11.20",
+ "resolved-pathbuf 0.2.0",
  "serde",
  "serde_json",
  "tokio",
@@ -8504,7 +8527,7 @@ dependencies = [
  "regex",
  "regex-automata 0.4.7",
  "regex-syntax 0.8.4",
- "reqwest",
+ "reqwest 0.11.20",
  "ring 0.16.20",
  "ring 0.17.8",
  "ripemd",
@@ -8762,6 +8785,35 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-opentelemetry 0.25.0",
+ "tracing-subscriber",
+ "trie-db",
+]
+
+[[package]]
+name = "merklize"
+version = "0.0.0"
+source = "git+https://github.com/fleek-network/lightning?rev=0.1.0-alpha.4#3b21025a5946fda345813453b58ca5c0f6dcb4e4"
+dependencies = [
+ "anyhow",
+ "atomo 0.0.5 (git+https://github.com/fleek-network/lightning?rev=0.1.0-alpha.4)",
+ "blake3",
+ "digest 0.10.7",
+ "fxhash",
+ "hash-db",
+ "hash256-std-hasher",
+ "hex",
+ "ics23",
+ "jmt",
+ "keccak-hasher",
+ "lru 0.12.4",
+ "reference-trie",
+ "schemars",
+ "serde",
+ "serde_json",
+ "sha2 0.10.8",
+ "thiserror",
+ "tiny-keccak",
+ "tracing",
  "tracing-subscriber",
  "trie-db",
 ]
@@ -9514,7 +9566,7 @@ dependencies = [
  "narwhal-worker",
  "prometheus",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.11.20",
  "sui-keys",
  "sui-protocol-config 0.1.0 (git+https://github.com/MystenLabs/sui.git?rev=bbfaafc17652d221651e835c908028c440f039d7)",
  "sui-types",
@@ -12170,7 +12222,7 @@ dependencies = [
  "http-body 0.4.6",
  "hyper 0.14.30",
  "hyper-rustls 0.24.2",
- "hyper-tls",
+ "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
  "log",
@@ -12196,6 +12248,50 @@ dependencies = [
  "web-sys",
  "webpki-roots 0.25.4",
  "winreg",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8f4955649ef5c38cc7f9e8aa41761d48fb9677197daea9984dc54f56aad5e63"
+dependencies = [
+ "base64 0.22.1",
+ "bytes 1.7.1",
+ "encoding_rs",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.4.5",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-rustls 0.27.2",
+ "hyper-tls 0.6.0",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile 2.1.2",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.1",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-registry",
 ]
 
 [[package]]
@@ -12225,6 +12321,16 @@ dependencies = [
  "resolve-path",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "resolved-pathbuf"
+version = "0.2.0"
+source = "git+https://github.com/fleek-network/lightning?rev=0.1.0-alpha.4#3b21025a5946fda345813453b58ca5c0f6dcb4e4"
+dependencies = [
+ "derive_more",
+ "resolve-path",
+ "serde",
 ]
 
 [[package]]
@@ -14176,7 +14282,7 @@ dependencies = [
  "fs2",
  "hex",
  "once_cell",
- "reqwest",
+ "reqwest 0.11.20",
  "semver 1.0.23",
  "serde",
  "serde_json",
@@ -14238,6 +14344,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14258,6 +14373,27 @@ dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.36",
  "syn 2.0.72",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.6.0",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -16189,6 +16325,36 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+dependencies = [
+ "windows-result",
+ "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
  "windows-targets 0.52.6",
 ]
 

--- a/core/application/src/env.rs
+++ b/core/application/src/env.rs
@@ -298,6 +298,10 @@ impl ApplicationEnv {
                 ProtocolParamKey::MinNumMeasurements,
                 ProtocolParamValue::MinNumMeasurements(genesis.min_num_measurements)
             );
+            param_table.insert(
+                ProtocolParamKey::SGXSharedPubKey,
+                ProtocolParamValue::SGXSharedPubKey(genesis.sgx_shared_pub_key)
+            );
 
             let epoch_end: u64 = genesis.epoch_time + genesis.epoch_start;
             let mut committee_members = Vec::with_capacity(4);

--- a/services/sgx/Cargo.toml
+++ b/services/sgx/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 # project libs
-fn-sdk = { git = "https://github.com/fleek-network/lightning", rev = "0.1.0-alpha.3" }
+fn-sdk = { git = "https://github.com/fleek-network/lightning", rev = "0.1.0-alpha.4" }
 dcap-quoteprov = { path = "../../lib/dcap-quoteprov" }
 
 # async
@@ -15,6 +15,7 @@ futures = "0.3"
 # io
 bytes = { version = "1.7", features = ["serde"]}
 arrayref = "0.3"
+reqwest = { version = "0.12", features = ["blocking"] }
 
 # encodings
 hex = "0.4"

--- a/services/sgx/src/lib.rs
+++ b/services/sgx/src/lib.rs
@@ -172,6 +172,7 @@ pub fn main() {
         if state_pub_key != enclave_pub_key {
             std::fs::remove_file(SGX_SEALED_DATA_PATH.join("sealedkey.bin"))
                 .expect("Failed to remove sealed secret key");
+            panic!("State public key doesn't match enclave public key");
         }
     });
 

--- a/services/sgx/src/req_res.rs
+++ b/services/sgx/src/req_res.rs
@@ -3,6 +3,7 @@ use std::io::Write;
 use std::ops::Deref;
 use std::sync::Arc;
 use std::task::Waker;
+use std::time::Duration;
 
 use aesm_client::AesmClient;
 use anyhow::{ensure, Context};
@@ -112,11 +113,34 @@ impl EndpointState {
     }
 
     pub fn handle_save_key(&self, data: Vec<u8>) -> std::io::Result<Bytes> {
-        std::fs::create_dir_all(SGX_SEALED_DATA_PATH.deref())?;
-        let mut file = File::create(SGX_SEALED_DATA_PATH.join("sealedkey.bin"))
-            .expect("Failed to create file");
-        file.write_all(&data)?;
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .thread_name("sdk")
+            .enable_all()
+            .build()
+            .expect("failed to build sdk runtime");
 
+        let state_pub_key =
+            rt.block_on(async move { fn_sdk::api::fetch_sgx_shared_pub_key().await });
+
+        // TODO(matthias): until we update the enclave to send the public key along with the
+        // encrypted shared secret key, we have to hit the http endpoint in the enclave to get the
+        // public key.
+        // Wait for enclave to start up.
+        std::thread::sleep(Duration::from_secs(10));
+
+        let enclave_pub_key = reqwest::blocking::get("http://127.0.0.1:8011/key")
+            .map_err(std::io::Error::other)?
+            .text()
+            .map_err(std::io::Error::other)?;
+
+        if state_pub_key == enclave_pub_key {
+            std::fs::create_dir_all(SGX_SEALED_DATA_PATH.deref())?;
+            let mut file = File::create(SGX_SEALED_DATA_PATH.join("sealedkey.bin"))
+                .expect("Failed to create file");
+            file.write_all(&data)?;
+        } else {
+            panic!("Enclave public key doesn't match public key on state");
+        }
         // no need to respond with anything
         Ok(Bytes::new())
     }


### PR DESCRIPTION
This adds a check to make sure that the public key corresponding to the enclave's shared secret key matches the public key on the application state. If the keys don't match, the sealed secret key is removed from disk and the runner panics, which will restart the service.
Since we currently don't return the public key from the enclave, we have to query the enclave's HTTP endpoint to get the public key. Once we update the enclave, we can remove that step.