### PR TITLE
feat: add clear and as_map to tableref

### DIFF
--- a/core/application/src/state/executor/epoch_change.rs
+++ b/core/application/src/state/executor/epoch_change.rs
@@ -81,9 +81,7 @@ impl<B: Backend> StateExecutor<B> {
             self.clean_up_content_registry();
 
             // Clear executed digests.
-            for digest in self.executed_digests.keys() {
-                self.executed_digests.remove(&digest);
-            }
+            self.executed_digests.clear();
 
             self.committee_info.set(current_epoch, current_committee);
             // Get new committee


### PR DESCRIPTION
Add `clear` and `as_map` methods to the atomo `TableRef`, and add `clear` to application executor `TableRef`, along with some test coverage. Both are helpers methods that I'm using in the random beacon work. I think these make sense at the atomo / db table level because the operations can be done in a more efficient way by the backend, vs just using the keys iterator, so better to just abstract them away from users of atomo now even if we don't optimize yet.