### PR TITLE
feat(app): epochs per year protocol param

### DIFF
--- a/core/application/networks/localnet-example/genesis.toml
+++ b/core/application/networks/localnet-example/genesis.toml
@@ -1,6 +1,7 @@
 chain_id = 1337
 epoch_start = 1684276288383
 epoch_time = 120000
+epochs_per_year = 365
 committee_size = 10
 node_count = 100
 min_stake = 1000

--- a/core/application/networks/testnet-stable/genesis.toml
+++ b/core/application/networks/testnet-stable/genesis.toml
@@ -1,6 +1,7 @@
 chain_id = 59330
 epoch_start = 1722355659837
 epoch_time = 1800000
+epochs_per_year = 365
 committee_size = 12
 node_count = 100
 min_stake = 1000

--- a/core/application/src/env.rs
+++ b/core/application/src/env.rs
@@ -259,6 +259,10 @@ impl ApplicationEnv {
                 ProtocolParamValue::EpochTime(genesis.epoch_time)
             );
             param_table.insert(
+                ProtocolParamKey::EpochsPerYear,
+                ProtocolParamValue::EpochsPerYear(genesis.epochs_per_year)
+            );
+            param_table.insert(
                 ProtocolParamKey::MinimumNodeStake,
                 ProtocolParamValue::MinimumNodeStake(genesis.min_stake)
             );

--- a/core/application/src/tests/utils.rs
+++ b/core/application/src/tests/utils.rs
@@ -419,6 +419,7 @@ pub(crate) fn test_genesis() -> Genesis {
         chain_id: CHAIN_ID,
         epoch_start: 1684276288383,
         epoch_time: 120000,
+        epochs_per_year: 365,
         committee_size: 10,
         node_count: 10,
         min_stake: 1000,

--- a/core/test-utils/src/e2e/genesis.rs
+++ b/core/test-utils/src/e2e/genesis.rs
@@ -120,6 +120,7 @@ impl TestGenesisBuilder {
             chain_id: self.chain_id,
             epoch_start: 1684276288383,
             epoch_time: 120000,
+            epochs_per_year: 365,
             committee_size: 10,
             node_count: 10,
             min_stake: 1000,

--- a/core/types/src/genesis.rs
+++ b/core/types/src/genesis.rs
@@ -27,6 +27,7 @@ pub struct Genesis {
     pub chain_id: u32,
     pub epoch_start: u64,
     pub epoch_time: u64,
+    pub epochs_per_year: u64,
     pub committee_size: u64,
     pub node_count: u64,
     pub min_stake: u64,

--- a/core/types/src/state.rs
+++ b/core/types/src/state.rs
@@ -188,13 +188,16 @@ pub enum ProtocolParamKey {
     /// measurements have been reported, no reputation score will be computed in that epoch.
     MinNumMeasurements = 12,
     /// The public key corresponding to the secret key that is shared among the SGX enclaves
-    SGXSharedPubKey = 13
+    SGXSharedPubKey = 13,
+    /// The number of epochs per year
+    EpochsPerYear = 14,
 }
 
 /// The Value enum is a data type used to represent values in a key-value pair for a metadata table
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash, schemars::JsonSchema)]
 pub enum ProtocolParamValue {
     EpochTime(u64),
+    EpochsPerYear(u64),
     CommitteeSize(u64),
     NodeCount(u64),
     MinimumNodeStake(u64),
@@ -214,6 +217,7 @@ impl ProtocolParamValue {
     pub fn get_bytes(&self) -> Cow<'_, [u8]> {
         match self {
             ProtocolParamValue::EpochTime(i) => Cow::Owned(i.to_le_bytes().to_vec()),
+            ProtocolParamValue::EpochsPerYear(i) => Cow::Owned(i.to_le_bytes().to_vec()),
             ProtocolParamValue::CommitteeSize(i) => Cow::Owned(i.to_le_bytes().to_vec()),
             ProtocolParamValue::NodeCount(i) => Cow::Owned(i.to_le_bytes().to_vec()),
             ProtocolParamValue::MinimumNodeStake(i) => Cow::Owned(i.to_le_bytes().to_vec()),


### PR DESCRIPTION
This PR adds the `EpochsPerYear` protocol parameter, and uses it in place of the `365` constant that's referenced in a few places for that purpose.

The driver for this for me was to make [this test](https://github.com/fleek-network/lightning/blob/main/core/application/src/tests/epoch_change.rs#L429) work with a longer epoch change process (for the committee selection beacon) where iterating through 365 of them for the test isn't practical, but seems like it would be good for it to be a protocol param anyway.