### PR TITLE
test(e2e): streamline the tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8025,6 +8025,7 @@ dependencies = [
  "ethers",
  "fleek-crypto",
  "hp-fixed",
+ "humantime-serde",
  "ink-quill",
  "lightning-workspace-hack",
  "merklize",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7121,6 +7121,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
+ "tempfile",
+ "thiserror",
  "tokio",
  "toml 0.7.8",
  "tracing",

--- a/core/application/networks/localnet-example/genesis.toml
+++ b/core/application/networks/localnet-example/genesis.toml
@@ -18,6 +18,7 @@ supply_at_genesis = 1000000                                          # set to 1 
 min_num_measurements = 2
 protocol_fund_address = "0x2a8cf657769c264b0c7f88e3a716afdeaec1c318"
 governance_address = "0x2a8cf657769c264b0c7f88e3a716afdeaec1c318"
+reputation_ping_timeout = "15s"
 
 [[node_info]]
 owner = "0x959807B8D94B324A74117956731F09E2893aCd72"

--- a/core/application/networks/testnet-stable/genesis.toml
+++ b/core/application/networks/testnet-stable/genesis.toml
@@ -18,6 +18,7 @@ supply_at_genesis = 1000000                                          # set to 1 
 min_num_measurements = 4
 protocol_fund_address = "0x2a8cf657769c264b0c7f88e3a716afdeaec1c318"
 governance_address = "0x2a8cf657769c264b0c7f88e3a716afdeaec1c318"
+reputation_ping_timeout = "15s"
 
 
 [[node_info]]

--- a/core/application/src/config.rs
+++ b/core/application/src/config.rs
@@ -243,7 +243,7 @@ mod config_tests {
             genesis_path: None,
             ..Default::default()
         };
-        assert!(config.genesis().is_ok());
+        config.genesis().unwrap().unwrap();
     }
 
     #[test]
@@ -257,7 +257,7 @@ mod config_tests {
             genesis_path: Some(genesis_path),
             ..Default::default()
         };
-        assert!(config.genesis().is_ok());
+        config.genesis().unwrap().unwrap();
     }
 
     #[test]
@@ -267,7 +267,7 @@ mod config_tests {
             genesis_path: None,
             ..Default::default()
         };
-        assert!(config.genesis().is_ok());
+        assert!(config.genesis().unwrap().is_none());
     }
 
     #[test]

--- a/core/application/src/config.rs
+++ b/core/application/src/config.rs
@@ -243,7 +243,7 @@ mod config_tests {
             genesis_path: None,
             ..Default::default()
         };
-        config.genesis().unwrap().unwrap();
+        assert!(config.genesis().is_ok());
     }
 
     #[test]
@@ -257,7 +257,7 @@ mod config_tests {
             genesis_path: Some(genesis_path),
             ..Default::default()
         };
-        config.genesis().unwrap().unwrap();
+        assert!(config.genesis().is_ok());
     }
 
     #[test]
@@ -267,7 +267,7 @@ mod config_tests {
             genesis_path: None,
             ..Default::default()
         };
-        assert!(config.genesis().unwrap().is_none());
+        assert!(config.genesis().is_ok());
     }
 
     #[test]

--- a/core/application/src/env.rs
+++ b/core/application/src/env.rs
@@ -302,6 +302,10 @@ impl ApplicationEnv {
                 ProtocolParamKey::MinNumMeasurements,
                 ProtocolParamValue::MinNumMeasurements(genesis.min_num_measurements)
             );
+            param_table.insert(
+                ProtocolParamKey::ReputationPingTimeout,
+                ProtocolParamValue::ReputationPingTimeout(genesis.reputation_ping_timeout),
+            );
 
             let epoch_end: u64 = genesis.epoch_time + genesis.epoch_start;
             let mut committee_members = Vec::with_capacity(4);

--- a/core/application/src/tests/utils.rs
+++ b/core/application/src/tests/utils.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, HashMap};
 use std::net::IpAddr;
 use std::str::FromStr;
+use std::time::Duration;
 
 use affair::Socket;
 use anyhow::{anyhow, Result};
@@ -411,6 +412,7 @@ pub(crate) fn test_genesis() -> Genesis {
         ],
         total_served: HashMap::new(),
         latencies: None,
+        reputation_ping_timeout: Duration::from_secs(1),
     }
 }
 

--- a/core/e2e/Cargo.toml
+++ b/core/e2e/Cargo.toml
@@ -44,11 +44,15 @@ hp-fixed.workspace = true
 serial_test = "3.0.0"
 tracing.workspace = true
 fleek-blake3 = "1.5"
+thiserror.workspace = true
 
 toml = "0.7"
 resolve-path = "0.1.0"
 clap = { version = "4.2", features = ["derive"] }
 lightning-workspace-hack.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true
 
 [features]
 services = ["lightning-node-bindings/services"]

--- a/core/e2e/src/bin/spawn_swarm.rs
+++ b/core/e2e/src/bin/spawn_swarm.rs
@@ -74,7 +74,7 @@ fn main() -> Result<()> {
         if path.exists() {
             fs::remove_dir_all(&path).expect("Failed to clean up swarm directory before test.");
         }
-        let swarm = Swarm::builder()
+        let mut swarm = Swarm::builder()
             .with_directory(path)
             .with_min_port(12000)
             .with_num_nodes(args.num_nodes)

--- a/core/e2e/src/containerized_node.rs
+++ b/core/e2e/src/containerized_node.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use fleek_crypto::AccountOwnerSecretKey;
 use futures::Future;
 use lightning_blockstore::blockstore::Blockstore;
@@ -6,17 +8,23 @@ use lightning_interfaces::prelude::*;
 use lightning_interfaces::types::{NodePorts, Staking};
 use lightning_node::ContainedNode;
 use lightning_node_bindings::FullNodeComponents;
-use lightning_rpc::Rpc;
+use lightning_rpc::api::FleekApiClient;
+use lightning_rpc::{Rpc, RpcClient};
 use lightning_utils::config::TomlConfigProvider;
+use lightning_utils::poll::{poll_until, PollUntilError};
+use types::{Epoch, NodeIndex};
+
+use crate::error::SwarmError;
 
 pub struct ContainerizedNode {
     config: TomlConfigProvider<FullNodeComponents>,
     owner_secret_key: AccountOwnerSecretKey,
     node: ContainedNode<FullNodeComponents>,
-    index: usize,
+    index: NodeIndex,
     genesis_stake: Staking,
     ports: NodePorts,
     is_genesis_committee: bool,
+    started: bool,
 }
 
 impl ContainerizedNode {
@@ -24,7 +32,7 @@ impl ContainerizedNode {
         config: TomlConfigProvider<FullNodeComponents>,
         owner_secret_key: AccountOwnerSecretKey,
         ports: NodePorts,
-        index: usize,
+        index: NodeIndex,
         is_genesis_committee: bool,
         genesis_stake: Staking,
     ) -> Self {
@@ -40,19 +48,26 @@ impl ContainerizedNode {
             genesis_stake,
             ports,
             is_genesis_committee,
+            started: false,
         }
     }
 
-    pub async fn start(&self) -> anyhow::Result<()> {
+    pub async fn start(&mut self) -> anyhow::Result<()> {
         // This function has to return a result in order to use try_join_all in swarm.rs
         let handle = self.node.spawn();
         handle.await.unwrap()?;
+
+        self.started = true;
 
         Ok(())
     }
 
     pub fn shutdown(self) -> impl Future<Output = ()> {
         self.node.shutdown()
+    }
+
+    pub fn is_started(&self) -> bool {
+        self.started
     }
 
     pub fn get_ports(&self) -> &NodePorts {
@@ -64,11 +79,15 @@ impl ContainerizedNode {
         format!("http://{}", config.addr())
     }
 
+    pub fn get_rpc_client(&self) -> RpcClient {
+        RpcClient::new_no_auth(&self.get_rpc_address()).unwrap()
+    }
+
     pub fn get_owner_secret_key(&self) -> AccountOwnerSecretKey {
         self.owner_secret_key.clone()
     }
 
-    pub fn get_index(&self) -> usize {
+    pub fn get_index(&self) -> NodeIndex {
         self.index
     }
 
@@ -91,5 +110,37 @@ impl ContainerizedNode {
 
     pub fn is_genesis_committee(&self) -> bool {
         self.is_genesis_committee
+    }
+
+    pub fn provider(&self) -> &MultiThreadedProvider {
+        self.node.provider()
+    }
+
+    pub async fn wait_for_rpc_ready(&self) {
+        self.node.wait_for_rpc_ready().await
+    }
+
+    pub async fn wait_for_epoch_change(
+        &self,
+        new_epoch: Epoch,
+        timeout: Duration,
+    ) -> Result<(), SwarmError> {
+        poll_until(
+            || async {
+                let client = self.get_rpc_client();
+                let epoch = client
+                    .get_epoch()
+                    .await
+                    .map_err(|e| PollUntilError::ConditionError(e.to_string()))?;
+
+                (epoch == new_epoch)
+                    .then_some(())
+                    .ok_or(PollUntilError::ConditionNotSatisfied)
+            },
+            timeout,
+            Duration::from_millis(100),
+        )
+        .await
+        .map_err(|e| SwarmError::Internal(e.to_string()))
     }
 }

--- a/core/e2e/src/containerized_node.rs
+++ b/core/e2e/src/containerized_node.rs
@@ -131,7 +131,7 @@ impl ContainerizedNode {
                 let epoch = client
                     .get_epoch()
                     .await
-                    .map_err(|e| PollUntilError::ConditionError(e.to_string()))?;
+                    .map_err(|_| PollUntilError::ConditionNotSatisfied)?;
 
                 (epoch == new_epoch)
                     .then_some(())

--- a/core/e2e/src/error.rs
+++ b/core/e2e/src/error.rs
@@ -1,0 +1,21 @@
+use lightning_utils::poll::PollUntilError;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum SwarmError {
+    #[error("Timeout waiting for swarm to be ready")]
+    WaitForReadyTimeout,
+
+    #[error("Internal: {0}")]
+    Internal(String),
+}
+
+impl From<PollUntilError> for SwarmError {
+    fn from(error: PollUntilError) -> Self {
+        match error {
+            PollUntilError::Timeout => SwarmError::WaitForReadyTimeout,
+            PollUntilError::ConditionError(_) => SwarmError::Internal(error.to_string()),
+            PollUntilError::ConditionNotSatisfied => unreachable!(),
+        }
+    }
+}

--- a/core/e2e/src/lib.rs
+++ b/core/e2e/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod containerized_node;
+pub mod error;
 pub mod swarm;
 pub mod utils;

--- a/core/e2e/src/swarm.rs
+++ b/core/e2e/src/swarm.rs
@@ -215,6 +215,26 @@ impl Swarm {
         .await;
     }
 
+    pub async fn wait_for_rpc_ready_genesis_committee(&self) {
+        join_all(
+            self.started_nodes()
+                .iter()
+                .filter(|node| node.is_genesis_committee())
+                .map(|node| node.wait_for_rpc_ready()),
+        )
+        .await;
+    }
+
+    pub async fn wait_for_rpc_ready_non_genesis_committee(&self) {
+        join_all(
+            self.started_nodes()
+                .iter()
+                .filter(|node| !node.is_genesis_committee())
+                .map(|node| node.wait_for_rpc_ready()),
+        )
+        .await;
+    }
+
     /// Wait for all nodes to reach a new epoch.
     pub async fn wait_for_epoch_change(
         &self,

--- a/core/e2e/tests/checkpoint.rs
+++ b/core/e2e/tests/checkpoint.rs
@@ -1,67 +1,92 @@
-use std::fs;
 use std::time::{Duration, SystemTime};
 
-use anyhow::Result;
 use lightning_e2e::swarm::Swarm;
+use lightning_interfaces::BlockstoreInterface;
 use lightning_rpc::interface::Fleek;
 use lightning_rpc::RpcClient;
-use lightning_test_utils::config::LIGHTNING_TEST_HOME_DIR;
 use lightning_test_utils::logging;
-use resolved_pathbuf::ResolvedPathBuf;
-use serial_test::serial;
+use lightning_utils::poll::{poll_until, PollUntilError};
+use tempfile::tempdir;
 
 #[tokio::test]
-#[serial]
-async fn e2e_checkpoint() -> Result<()> {
+async fn e2e_checkpoint() {
     logging::setup();
 
-    // Start epoch now and let it end in 40 seconds.
-    let epoch_start = SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap()
-        .as_millis() as u64;
-
-    let path = ResolvedPathBuf::try_from(LIGHTNING_TEST_HOME_DIR.join("e2e/checkpoint")).unwrap();
-    if path.exists() {
-        fs::remove_dir_all(&path).expect("Failed to clean up swarm directory before test.");
-    }
-    let swarm = Swarm::builder()
-        .with_directory(path)
+    let temp_dir = tempdir().unwrap();
+    let mut swarm = Swarm::builder()
+        .with_directory(temp_dir.path().to_path_buf().try_into().unwrap())
         .with_min_port(10000)
         .with_num_nodes(4)
-        .with_epoch_time(30000)
-        .with_epoch_start(epoch_start)
+        // We need to include enough time in this epoch time for the nodes to start up, or else it
+        // begins the epoch change immediately when they do. We can even get into a situation where
+        // another epoch change starts quickly after that, causing our expectation of epoch = 1
+        // below to fail.
+        .with_epoch_time(15000)
+        .with_epoch_start(
+            SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_millis() as u64,
+        )
         .persistence(true)
         .build();
     swarm.launch().await.unwrap();
 
+    // Wait for RPC to be ready.
+    swarm.wait_for_rpc_ready().await;
+
     // Wait for the epoch to change.
-    tokio::time::sleep(Duration::from_secs(35)).await;
+    swarm
+        .wait_for_epoch_change(1, Duration::from_secs(60))
+        .await
+        .unwrap();
 
-    for (_, address) in swarm.get_rpc_addresses() {
-        let client = RpcClient::new_no_auth(&address)?;
-        let epoch = client.get_epoch().await?;
+    // Wait until the last epoch hash is not all zeroes and equal across all nodes.
+    // We need to do this because the last epoch hash is not updated atomically with the epoch
+    // change, and happens immediately after it, but we may check before it's been updated, so we
+    // need to wait/poll for a short period just in case.
+    let epoch_checkpoint_hash = poll_until(
+        || async {
+            // Check last epoch hash across all nodes.
+            let mut target_hash = None;
+            for (_, address) in swarm.get_rpc_addresses() {
+                let client = RpcClient::new_no_auth(&address).unwrap();
+                let (epoch_hash, _) = client.get_last_epoch_hash().await.unwrap();
+                if target_hash.is_none() {
+                    target_hash = Some(epoch_hash);
+                }
+                if epoch_hash != target_hash.unwrap() {
+                    return Err(PollUntilError::ConditionNotSatisfied);
+                }
+            }
+            let target_hash = target_hash.unwrap();
 
-        assert_eq!(epoch, 1);
+            // Check that the epoch hash is not all zeros, which would indicate that the checkpoint
+            // was not stored, since that's the default.
+            (target_hash != [0; 32])
+                .then_some(target_hash)
+                .ok_or(PollUntilError::ConditionNotSatisfied)
+        },
+        Duration::from_secs(5),
+        Duration::from_millis(100),
+    )
+    .await
+    .unwrap();
+
+    // Check that the epoch hash is not all zeros, which would indicate that the checkpoint
+    // was not stored, since that's the default.
+    assert_ne!(epoch_checkpoint_hash, [0; 32]);
+
+    // Get the checkpoint from blockstores across all nodes and make sure they all match the
+    // expected checkpoint hash.
+    for blockstore in swarm.get_blockstores() {
+        let checkpoint = blockstore
+            .read_all_to_vec(&epoch_checkpoint_hash)
+            .await
+            .unwrap();
+        let checkpoint_hash = fleek_blake3::hash(&checkpoint);
+        assert_eq!(checkpoint_hash, epoch_checkpoint_hash);
     }
-
-    let mut target_hash = None;
-    for (_, address) in swarm.get_rpc_addresses() {
-        let client = RpcClient::new_no_auth(&address)?;
-        let (epoch_hash, _) = client.get_last_epoch_hash().await?;
-
-        if target_hash.is_none() {
-            target_hash = Some(epoch_hash);
-            // Make sure that we stored an epoch hash.
-            assert_ne!(target_hash.unwrap(), [0; 32]);
-        }
-
-        // Make sure that all nodes stored the same hash for the epoch state.
-        assert_eq!(epoch_hash, target_hash.unwrap());
-    }
-    // TODO(matthias): read the block stores of all the nodes and make sure they all stored the
-    // checkpoint
 
     swarm.shutdown().await;
-    Ok(())
 }

--- a/core/e2e/tests/epoch_change.rs
+++ b/core/e2e/tests/epoch_change.rs
@@ -76,10 +76,15 @@ async fn e2e_epoch_change_with_some_nodes_not_on_committee() {
                 .as_millis() as u64,
         )
         .build();
-    swarm.launch().await.unwrap();
 
-    // Wait for RPC to be ready.
-    swarm.wait_for_rpc_ready().await;
+    // Launch genesis committee and wait for RPC to be ready on them.
+    swarm.launch_genesis_committee().await.unwrap();
+    swarm.wait_for_rpc_ready_genesis_committee().await;
+
+    // Launch the non-committee node now that the committee/bootstrap nodes are up, and wait for RPC
+    // to be ready on them.
+    swarm.launch_non_genesis_committee().await.unwrap();
+    swarm.wait_for_rpc_ready_non_genesis_committee().await;
 
     // Check that the initial epoch is 0 across all nodes.
     for (_, client) in swarm.get_rpc_clients() {

--- a/core/e2e/tests/pinger.rs
+++ b/core/e2e/tests/pinger.rs
@@ -1,51 +1,47 @@
-use std::fs;
 use std::time::{Duration, SystemTime};
 
-use anyhow::Result;
 use lightning_e2e::swarm::Swarm;
 use lightning_interfaces::types::Participation;
 use lightning_rpc::api::RpcClient;
 use lightning_rpc::interface::Fleek;
-use lightning_test_utils::config::LIGHTNING_TEST_HOME_DIR;
 use lightning_test_utils::logging;
-use resolved_pathbuf::ResolvedPathBuf;
-use serial_test::serial;
+use tempfile::tempdir;
 
 #[tokio::test]
-#[serial]
-async fn e2e_detect_offline_node() -> Result<()> {
+async fn e2e_detect_offline_node() {
     logging::setup();
 
-    // Start epoch now and let it end in 40 seconds.
-    let epoch_start = SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap()
-        .as_millis() as u64;
-
-    let path = ResolvedPathBuf::try_from(LIGHTNING_TEST_HOME_DIR.join("e2e/pinger")).unwrap();
-    if path.exists() {
-        fs::remove_dir_all(&path).expect("Failed to clean up swarm directory before test.");
-    }
-    let swarm = Swarm::builder()
-        .with_directory(path)
+    let temp_dir = tempdir().unwrap();
+    let mut swarm = Swarm::builder()
+        .with_directory(temp_dir.path().to_path_buf().try_into().unwrap())
         .with_min_port(10500)
         .with_num_nodes(5)
         .with_committee_size(4)
-        .with_epoch_time(25000)
-        .with_epoch_start(epoch_start)
+        // We need to include enough time in this epoch time for the nodes to start up and for some
+        // pings to fail against the offline node, and for those reputation measurements to be
+        // submitted, before the epoch change. Otherwise, the offline will still be marked as
+        // participating = true and our expectation below will fail.
+        .with_epoch_time(20000)
+        .with_ping_interval(Duration::from_secs(1))
+        .with_ping_timeout(Duration::from_secs(1))
+        .with_epoch_start(
+            SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_millis() as u64,
+        )
         .persistence(true)
         .build();
     swarm.launch_genesis_committee().await.unwrap();
 
-    // Wait for the epoch to change.
-    tokio::time::sleep(Duration::from_secs(30)).await;
+    // Wait for RPC to be ready.
+    swarm.wait_for_rpc_ready().await;
 
-    for (_, address) in swarm.get_genesis_committee_rpc_addresses() {
-        let client = RpcClient::new_no_auth(&address)?;
-        let epoch = client.get_epoch().await?;
-
-        assert_eq!(epoch, 1);
-    }
+    // Wait for epoch to change.
+    swarm
+        .wait_for_epoch_change(1, Duration::from_secs(60))
+        .await
+        .unwrap();
 
     // Get the public key of the node that was offline.
     let (pubkey, _) = swarm
@@ -56,15 +52,15 @@ async fn e2e_detect_offline_node() -> Result<()> {
 
     // Make sure that the offline node was removed from participation.
     for (_, address) in swarm.get_genesis_committee_rpc_addresses() {
-        let client = RpcClient::new_no_auth(&address)?;
+        let client = RpcClient::new_no_auth(&address).unwrap();
         let node_info = client
             .get_node_info(pubkey, None)
-            .await?
+            .await
+            .unwrap()
             .expect("No node info recieved from rpc");
 
         assert_eq!(node_info.participation, Participation::False);
     }
 
     swarm.shutdown().await;
-    Ok(())
 }

--- a/core/node/src/lib.rs
+++ b/core/node/src/lib.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 use anyhow::Result;
 use lightning_interfaces::prelude::*;
 use lightning_interfaces::ShutdownController;
+use lightning_rpc::Rpc;
 use tokio::runtime::{Handle, Runtime};
 use tokio::task::JoinHandle;
 use tokio::time::timeout;
@@ -188,6 +189,11 @@ impl<C: NodeComponents> ContainedNode<C> {
     /// Returns a reference to the data provider.
     pub fn provider(&self) -> &fdi::MultiThreadedProvider {
         &self.provider
+    }
+
+    /// Wait for the RPC component to be ready.
+    pub async fn wait_for_rpc_ready(&self) {
+        self.provider.get::<Rpc<C>>().wait_for_ready().await;
     }
 }
 

--- a/core/pinger/src/pinger.rs
+++ b/core/pinger/src/pinger.rs
@@ -206,7 +206,11 @@ impl<C: NodeComponents> PingerInner<C> {
                             spawn!(async move {
                                 tokio::time::sleep(timeout).await;
                                 // We ignore the sending error because it can happen that the
+                                // pinger is shutdown while there are still pending timeout tasks.
+                                let _ = tx.send((peer_index, id)).await;
+                            },
                             "PINGER: request timeout");
+                        }
                     }
                 }
                 timeout = timeout_rx.recv() => {

--- a/core/rpc/src/lib.rs
+++ b/core/rpc/src/lib.rs
@@ -239,7 +239,7 @@ impl<C: NodeComponents> Rpc<C> {
         spawn!(
             async move {
                 shutdown.wait_for_shutdown().await;
-                server_handle.stop().unwrap();
+                let _ = server_handle.stop();
                 server_handle.stopped().await;
             },
             "RPC: shutdown waiter"

--- a/core/test-utils/src/e2e/genesis.rs
+++ b/core/test-utils/src/e2e/genesis.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::str::FromStr;
+use std::time::Duration;
 
 use fleek_crypto::{AccountOwnerSecretKey, EthAddress, SecretKey};
 use hp_fixed::unsigned::HpUfixed;
@@ -164,6 +165,7 @@ impl TestGenesisBuilder {
             ],
             total_served: HashMap::new(),
             latencies: None,
+            reputation_ping_timeout: Duration::from_secs(1),
         };
 
         if let Some(mutator) = self.mutator {

--- a/core/types/Cargo.toml
+++ b/core/types/Cargo.toml
@@ -31,6 +31,7 @@ lightning-workspace-hack.workspace = true
 resolved-pathbuf.workspace = true
 serde_with.workspace = true
 toml.workspace = true
+humantime-serde.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/core/types/src/genesis.rs
+++ b/core/types/src/genesis.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::fs;
 use std::net::IpAddr;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use fleek_crypto::{ClientPublicKey, ConsensusPublicKey, EthAddress, NodePublicKey};
@@ -55,6 +56,8 @@ pub struct Genesis {
     #[serde_as(as = "HashMap<DisplayFromStr, _>")]
     pub total_served: HashMap<Epoch, GenesisTotalServed>,
     pub latencies: Option<Vec<GenesisLatency>>,
+    #[serde(with = "humantime_serde")]
+    pub reputation_ping_timeout: Duration,
 }
 
 impl Genesis {

--- a/core/types/src/state.rs
+++ b/core/types/src/state.rs
@@ -2,6 +2,7 @@
 use std::borrow::Cow;
 use std::fmt::Display;
 use std::net::IpAddr;
+use std::time::Duration;
 
 use anyhow::anyhow;
 use fleek_crypto::{ConsensusPublicKey, EthAddress, NodePublicKey};
@@ -191,6 +192,8 @@ pub enum ProtocolParamKey {
     SGXSharedPubKey = 13,
     /// The number of epochs per year
     EpochsPerYear = 14,
+    /// The ping timeout for node reputation.
+    ReputationPingTimeout = 15,
 }
 
 /// The Value enum is a data type used to represent values in a key-value pair for a metadata table
@@ -211,6 +214,7 @@ pub enum ProtocolParamValue {
     MaxStakeLockTime(u64),
     MinNumMeasurements(u64),
     SGXSharedPubKey(String),
+    ReputationPingTimeout(Duration),
 }
 
 impl ProtocolParamValue {
@@ -231,6 +235,9 @@ impl ProtocolParamValue {
             ProtocolParamValue::MaxStakeLockTime(i) => Cow::Owned(i.to_le_bytes().to_vec()),
             ProtocolParamValue::MinNumMeasurements(i) => Cow::Owned(i.to_le_bytes().to_vec()),
             ProtocolParamValue::SGXSharedPubKey(s) => Cow::Borrowed(s.as_bytes()),
+            ProtocolParamValue::ReputationPingTimeout(d) => {
+                Cow::Owned(d.as_millis().to_le_bytes().to_vec())
+            },
         }
     }
 }

--- a/core/utils/src/application.rs
+++ b/core/utils/src/application.rs
@@ -204,6 +204,16 @@ pub trait QueryRunnerExt: SyncQueryRunnerInterface {
                 .is_some_and(|node_stake| node_stake >= minimum_stake_amount)
         })
     }
+
+    /// Returns the ping timeout from the protocol parameters.
+    fn get_reputation_ping_timeout(&self) -> Duration {
+        match self.get_protocol_param(&ProtocolParamKey::ReputationPingTimeout) {
+            Some(ProtocolParamValue::ReputationPingTimeout(timeout)) => timeout,
+            // Return 15s if the param is not set, for backwards compatibility.
+            None => Duration::from_secs(15),
+            _ => unreachable!(),
+        }
+    }
 }
 
 impl<T: SyncQueryRunnerInterface> QueryRunnerExt for T {}

--- a/flake.nix
+++ b/flake.nix
@@ -260,7 +260,7 @@
                 inherit cargoArtifacts;
                 partitions = 1;
                 partitionType = "count";
-                cargoNextestExtraArgs = "--workspace --exclude lightning-e2e";
+                cargoNextestExtraArgs = "--workspace";
               }
             );
           };


### PR DESCRIPTION
This PR streamlines the e2e tests using the wait-for-ready and poll-until patterns, making them faster and less flakey. It also adds a protocol param for the reputation ping timeout, previously a 15s constant in the pinger component, and updates `flake.nix` to not exclude e2e tests in CI.

```
PASS [  14.314s] lightning-e2e::syncronizer e2e_syncronize_state
PASS [  16.298s] lightning-e2e::pinger e2e_detect_offline_node
PASS [  18.452s] lightning-e2e::epoch_change e2e_epoch_change_with_some_nodes_not_on_committee
PASS [  18.619s] lightning-e2e::epoch_change e2e_test_staking_auction
PASS [  18.752s] lightning-e2e::checkpoint e2e_checkpoint
PASS [  18.774s] lightning-e2e::epoch_change e2e_epoch_change_all_nodes_on_committee
```

I ran these tests in a loop for a couple hours and didn't hit any failures. If the epoch times go much lower than currently configured there are a few different race conditions that surface (inline comments with more detail on them). They aren't insurmountable to smooth out, but this felt like a good enough place to leave it for now, this is enough for the committee beacon process to be introduced more smoothly.