### PR TITLE
chore(tx-client): backfill nonce on no more attempts and default retry only on invalid nonce

### DIFF
--- a/core/types/src/transaction_client.rs
+++ b/core/types/src/transaction_client.rs
@@ -96,7 +96,7 @@ impl ExecuteTransactionRetry {
 
     pub fn should_retry_on_error(&self, error: &ExecutionError) -> bool {
         match self {
-            Self::Default => true,
+            Self::Default => *error == ExecutionError::InvalidNonce,
             Self::Never => false,
             Self::Always(_) => true,
             Self::AlwaysExcept((_, errors, _)) => errors

--- a/core/utils/src/transaction/nonce.rs
+++ b/core/utils/src/transaction/nonce.rs
@@ -30,6 +30,11 @@ impl NonceState {
         next
     }
 
+    pub async fn get_next(&self) -> u64 {
+        let inner = self.inner.read().await;
+        inner.next
+    }
+
     pub async fn get_base(&self) -> u64 {
         let inner = self.inner.read().await;
         inner.base


### PR DESCRIPTION
This PR updates the transaction client to
- Backfill the nonce before giving up to avoid invalidating in-flight transactions
- Default retry only on `InvalidNonce` revert error