### PR TITLE
chore(app): clean up valid node criteria and node participation on unstake

### DIFF
--- a/core/application/src/state/executor/epoch_change.rs
+++ b/core/application/src/state/executor/epoch_change.rs
@@ -42,7 +42,7 @@ impl<B: Backend> StateExecutor<B> {
         epoch: Epoch,
     ) -> TransactionResponse {
         // Only Nodes can call this function
-        let index = match self.only_node(sender) {
+        let index = match self.only_node_with_sufficient_stake_and_participating(sender) {
             Ok(account) => account,
             Err(e) => return e,
         };
@@ -122,7 +122,7 @@ impl<B: Backend> StateExecutor<B> {
         commit: CommitteeSelectionBeaconCommit,
     ) -> TransactionResponse {
         // Check that a node is sending the transaction, and get the node's index.
-        let node_index = match self.only_node(sender) {
+        let node_index = match self.only_node_with_sufficient_stake(sender) {
             Ok(account) => account,
             Err(e) => return e,
         };
@@ -220,7 +220,7 @@ impl<B: Backend> StateExecutor<B> {
         reveal: CommitteeSelectionBeaconReveal,
     ) -> TransactionResponse {
         // Check that a node is sending the transaction, and get the node's index.
-        let node_index = match self.only_node(sender) {
+        let node_index = match self.only_node_with_sufficient_stake(sender) {
             Ok(account) => account,
             Err(e) => return e,
         };
@@ -330,7 +330,7 @@ impl<B: Backend> StateExecutor<B> {
         sender: TransactionSender,
     ) -> TransactionResponse {
         // Check that a node is sending the transaction, and get the node's index.
-        let _node_index = match self.only_node(sender) {
+        let _node_index = match self.only_node_with_sufficient_stake(sender) {
             Ok(account) => account,
             Err(e) => return e,
         };
@@ -440,7 +440,7 @@ impl<B: Backend> StateExecutor<B> {
         sender: TransactionSender,
     ) -> TransactionResponse {
         // Check that a node is sending the transaction, and get the node's index.
-        let _node_index = match self.only_node(sender) {
+        let _node_index = match self.only_node_with_sufficient_stake(sender) {
             Ok(account) => account,
             Err(e) => return e,
         };

--- a/core/application/src/tests/epoch_change.rs
+++ b/core/application/src/tests/epoch_change.rs
@@ -457,8 +457,16 @@ async fn test_epoch_change_reverts_not_committee_member() {
     )
     .await;
 
+    // Execute opt-in transaction.
+    expect_tx_success(
+        prepare_update_request_node(UpdateMethod::OptIn {}, &node_secret_key, 1),
+        &update_socket,
+        ExecutionData::None,
+    )
+    .await;
+
     let change_epoch = UpdateMethod::ChangeEpoch { epoch: 0 };
-    let update = prepare_update_request_node(change_epoch, &node_secret_key, 1);
+    let update = prepare_update_request_node(change_epoch, &node_secret_key, 2);
     expect_tx_revert(update, &update_socket, ExecutionError::NotCommitteeMember).await;
 }
 

--- a/core/application/src/tests/everything_else.rs
+++ b/core/application/src/tests/everything_else.rs
@@ -20,7 +20,7 @@ use tempfile::tempdir;
 use super::utils::*;
 
 #[tokio::test]
-async fn test_is_valid_node() {
+async fn test_has_sufficient_stake() {
     let temp_dir = tempdir().unwrap();
 
     let (update_socket, query_runner) = init_app(&temp_dir, None);
@@ -41,7 +41,7 @@ async fn test_is_valid_node() {
     .await;
 
     // Make sure that this node is a valid node.
-    assert!(query_runner.is_valid_node(&node_pub_key));
+    assert!(query_runner.has_sufficient_stake(&node_pub_key));
 
     // Generate new keys for a different node.
     let owner_secret_key = AccountOwnerSecretKey::generate();
@@ -59,7 +59,7 @@ async fn test_is_valid_node() {
     )
     .await;
     // Make sure that this node is not a valid node.
-    assert!(!query_runner.is_valid_node(&node_pub_key));
+    assert!(!query_runner.has_sufficient_stake(&node_pub_key));
 }
 
 #[tokio::test]

--- a/core/application/src/tests/reputation.rs
+++ b/core/application/src/tests/reputation.rs
@@ -277,6 +277,14 @@ async fn test_submit_reputation_measurements_too_many_measurements() {
     )
     .await;
 
+    // Execute opt-in transaction.
+    expect_tx_success(
+        prepare_update_request_node(UpdateMethod::OptIn {}, &node_secret_key, 1),
+        &update_socket,
+        ExecutionData::None,
+    )
+    .await;
+
     let mut measurements = BTreeMap::new();
 
     // create many dummy measurements that len >
@@ -286,7 +294,7 @@ async fn test_submit_reputation_measurements_too_many_measurements() {
     let update = prepare_update_request_node(
         UpdateMethod::SubmitReputationMeasurements { measurements },
         &node_secret_key,
-        1,
+        2,
     );
 
     expect_tx_revert(update, &update_socket, ExecutionError::TooManyMeasurements).await;

--- a/core/application/src/tests/utils.rs
+++ b/core/application/src/tests/utils.rs
@@ -1,6 +1,8 @@
 use std::collections::{BTreeMap, HashMap};
 use std::net::IpAddr;
 use std::str::FromStr;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 
 use affair::Socket;
@@ -31,7 +33,11 @@ use lightning_interfaces::types::{
 };
 use lightning_interfaces::PagingParams;
 use lightning_node::Node;
+use lightning_test_utils::e2e::{try_init_tracing, TestGenesisBuilder, TestGenesisNodeBuilder};
 use lightning_test_utils::json_config::JsonConfigProvider;
+use lightning_test_utils::keys::EphemeralKeystore;
+use lightning_utils::application::QueryRunnerExt;
+use lightning_utils::transaction::{TransactionBuilder, TransactionSigner};
 use tempfile::TempDir;
 use types::{
     AccountInfo,
@@ -59,6 +65,7 @@ use types::{
 };
 
 use super::TestBinding;
+use crate::config::StorageConfig;
 use crate::state::QueryRunner;
 use crate::{Application, ApplicationConfig};
 
@@ -941,4 +948,242 @@ pub(crate) fn content_registry(query_runner: &QueryRunner, node: &NodeIndex) -> 
         .unwrap_or_default()
         .into_iter()
         .collect()
+}
+
+pub struct TestNetworkBuilder {
+    committee_nodes: usize,
+    non_committee_nodes: usize,
+    commit_phase_duration: u64,
+    reveal_phase_duration: u64,
+    stake_lock_time: u64,
+}
+
+impl Default for TestNetworkBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TestNetworkBuilder {
+    pub fn new() -> Self {
+        Self {
+            committee_nodes: 0,
+            non_committee_nodes: 0,
+            commit_phase_duration: 2,
+            reveal_phase_duration: 2,
+            stake_lock_time: 5,
+        }
+    }
+
+    pub fn with_committee_nodes(mut self, committee_nodes: usize) -> Self {
+        self.committee_nodes = committee_nodes;
+        self
+    }
+
+    pub fn with_non_committee_nodes(mut self, non_committee_nodes: usize) -> Self {
+        self.non_committee_nodes = non_committee_nodes;
+        self
+    }
+
+    pub fn with_commit_phase_duration(mut self, commit_phase_duration: u64) -> Self {
+        self.commit_phase_duration = commit_phase_duration;
+        self
+    }
+
+    pub fn with_reveal_phase_duration(mut self, reveal_phase_duration: u64) -> Self {
+        self.reveal_phase_duration = reveal_phase_duration;
+        self
+    }
+
+    pub fn with_stake_lock_time(mut self, stake_lock_time: u64) -> Self {
+        self.stake_lock_time = stake_lock_time;
+        self
+    }
+
+    pub async fn build(&self) -> Result<TestNetwork> {
+        let _ = try_init_tracing(None);
+
+        let config = JsonConfigProvider::default()
+            .with::<Application<TestBinding>>(ApplicationConfig {
+                network: None,
+                genesis_path: None,
+                storage: StorageConfig::InMemory,
+                db_path: None,
+                db_options: None,
+                dev: None,
+            })
+            .with::<EphemeralKeystore<TestBinding>>(Default::default());
+        let provider = fdi::Provider::default().with(config);
+        let node = Node::<TestBinding>::init_with_provider(provider)?;
+
+        let app = node.provider.get::<Application<TestBinding>>();
+
+        let chain_id = 1337;
+        let stake_lock_time = self.stake_lock_time;
+        let commit_phase_duration = self.commit_phase_duration;
+        let reveal_phase_duration = self.reveal_phase_duration;
+        let mut builder = TestGenesisBuilder::new()
+            .with_chain_id(chain_id)
+            .with_mutator(Arc::new(move |genesis: &mut Genesis| {
+                genesis.lock_time = stake_lock_time;
+                genesis.committee_selection_beacon_commit_phase_duration = commit_phase_duration;
+                genesis.committee_selection_beacon_reveal_phase_duration = reveal_phase_duration;
+            }));
+
+        let mut nodes = vec![];
+
+        for _ in 0..self.committee_nodes {
+            let keystore = EphemeralKeystore::<TestBinding>::default();
+            let signer = TransactionSigner::NodeMain(keystore.get_ed25519_sk());
+            let owner_secret_key = AccountOwnerSecretKey::generate();
+            builder = builder.with_node(
+                TestGenesisNodeBuilder::new()
+                    .with_owner(owner_secret_key.to_pk().into())
+                    .with_node_secret_key(keystore.get_ed25519_sk())
+                    .with_consensus_secret_key(keystore.get_bls_sk())
+                    .with_stake(Staking {
+                        staked: 1000u32.into(),
+                        stake_locked_until: 0,
+                        locked: 0u32.into(),
+                        locked_until: 0,
+                    })
+                    .with_is_committee(true)
+                    .build(),
+            );
+            nodes.push(TestNode {
+                keystore,
+                signer,
+                chain_id,
+                nonce: Arc::new(AtomicU64::new(0)),
+                owner_secret_key,
+            });
+        }
+
+        for _ in 0..self.non_committee_nodes {
+            let keystore = EphemeralKeystore::<TestBinding>::default();
+            let signer = TransactionSigner::NodeMain(keystore.get_ed25519_sk());
+            let owner_secret_key = AccountOwnerSecretKey::generate();
+            builder = builder.with_node(
+                TestGenesisNodeBuilder::new()
+                    .with_owner(owner_secret_key.to_pk().into())
+                    .with_node_secret_key(keystore.get_ed25519_sk())
+                    .with_is_committee(false)
+                    .build(),
+            );
+            nodes.push(TestNode {
+                keystore,
+                signer,
+                chain_id,
+                nonce: Arc::new(AtomicU64::new(0)),
+                owner_secret_key,
+            });
+        }
+
+        let genesis = builder.build();
+        app.apply_genesis(genesis).await?;
+
+        let tx_socket = app.transaction_executor();
+        let query = app.sync_query();
+
+        Ok(TestNetwork {
+            chain_id,
+            _primary: node,
+            nodes,
+            tx_socket,
+            query,
+        })
+    }
+}
+
+pub struct TestNetwork {
+    _primary: Node<TestBinding>,
+    pub nodes: Vec<TestNode>,
+    tx_socket: ExecutionEngineSocket,
+    pub query: QueryRunner,
+    pub chain_id: ChainId,
+}
+
+impl TestNetwork {
+    pub fn builder() -> TestNetworkBuilder {
+        TestNetworkBuilder::new()
+    }
+
+    pub fn node(&self, index: NodeIndex) -> &TestNode {
+        &self.nodes[index as usize]
+    }
+
+    pub fn query(&self) -> QueryRunner {
+        self.query.clone()
+    }
+
+    pub async fn maybe_execute(
+        &self,
+        transactions: Vec<TransactionRequest>,
+    ) -> Result<BlockExecutionResponse> {
+        self.tx_socket
+            .run(Block {
+                transactions,
+                ..Default::default()
+            })
+            .await
+            .map_err(|e| anyhow::anyhow!(e))
+    }
+
+    pub async fn execute(
+        &self,
+        transactions: Vec<TransactionRequest>,
+    ) -> Result<BlockExecutionResponse> {
+        let resp = self.maybe_execute(transactions.clone()).await?;
+        for receipt in &resp.txn_receipts {
+            if !matches!(receipt.response, TransactionResponse::Success(_)) {
+                anyhow::bail!("transaction execution failed: {:?}", receipt);
+            }
+        }
+        if resp.txn_receipts.len() != transactions.len() {
+            anyhow::bail!(
+                "expected {} transactions, got {}",
+                transactions.len(),
+                resp.txn_receipts.len()
+            );
+        }
+        Ok(resp)
+    }
+
+    pub async fn execute_change_epoch(&self, epoch: Epoch) -> Result<BlockExecutionResponse> {
+        let current_committee = self.query.get_committee_members_by_index();
+        let transactions = self
+            .nodes
+            .iter()
+            .filter(|node| {
+                current_committee.contains(
+                    &self
+                        .query
+                        .pubkey_to_index(&node.keystore.get_ed25519_pk())
+                        .unwrap(),
+                )
+            })
+            .map(|node| node.build_transaction(UpdateMethod::ChangeEpoch { epoch }))
+            .collect();
+        self.execute(transactions).await
+    }
+}
+
+pub struct TestNode {
+    pub keystore: EphemeralKeystore<TestBinding>,
+    pub signer: TransactionSigner,
+    pub chain_id: ChainId,
+    nonce: Arc<AtomicU64>,
+    pub owner_secret_key: AccountOwnerSecretKey,
+}
+
+impl TestNode {
+    pub fn build_transaction(&self, method: UpdateMethod) -> TransactionRequest {
+        TransactionBuilder::from_update(
+            method,
+            self.chain_id,
+            self.nonce.fetch_add(1, Ordering::Relaxed) + 1,
+            &self.signer,
+        )
+        .into()
+    }
 }

--- a/core/rpc/src/api/flk.rs
+++ b/core/rpc/src/api/flk.rs
@@ -150,11 +150,8 @@ pub trait FleekApi {
         epoch: Option<u64>,
     ) -> RpcResult<NodeServed>;
 
-    #[method(name = "is_valid_node")]
-    async fn is_valid_node(&self, public_key: NodePublicKey) -> RpcResult<bool>;
-
-    #[method(name = "is_valid_node_epoch")]
-    async fn is_valid_node_epoch(&self, public_key: NodePublicKey) -> RpcResult<(bool, Epoch)>;
+    #[method(name = "node_has_sufficient_stake")]
+    async fn node_has_sufficient_stake(&self, public_key: NodePublicKey) -> RpcResult<bool>;
 
     #[method(name = "get_node_registry")]
     async fn get_node_registry(&self, paging: Option<PagingParams>) -> RpcResult<Vec<NodeInfo>>;

--- a/core/rpc/src/logic/flk_impl.rs
+++ b/core/rpc/src/logic/flk_impl.rs
@@ -298,15 +298,8 @@ impl<C: NodeComponents> FleekApiServer for FleekApi<C> {
             .unwrap_or_default())
     }
 
-    async fn is_valid_node(&self, pk: NodePublicKey) -> RpcResult<bool> {
-        Ok(self.data.query_runner.is_valid_node(&pk))
-    }
-
-    async fn is_valid_node_epoch(&self, pk: NodePublicKey) -> RpcResult<(bool, Epoch)> {
-        Ok((
-            self.data.query_runner.is_valid_node(&pk),
-            self.data.query_runner.get_epoch_info().epoch,
-        ))
+    async fn node_has_sufficient_stake(&self, pk: NodePublicKey) -> RpcResult<bool> {
+        Ok(self.data.query_runner.has_sufficient_stake(&pk))
     }
 
     async fn get_node_registry(&self, paging: Option<PagingParams>) -> RpcResult<Vec<NodeInfo>> {

--- a/core/rpc/src/tests.rs
+++ b/core/rpc/src/tests.rs
@@ -600,7 +600,7 @@ async fn test_rpc_get_node_served() {
 }
 
 #[tokio::test]
-async fn test_rpc_is_valid_node() {
+async fn test_rpc_node_has_sufficient_stake() {
     let mut network = TestNetwork::builder()
         .with_committee_nodes::<TestFullNodeComponentsWithMockConsensus>(1)
         .await
@@ -617,10 +617,12 @@ async fn test_rpc_is_valid_node() {
         .node(0)
         .downcast::<TestFullNodeComponentsWithMockConsensus>();
 
-    let response =
-        FleekApiClient::is_valid_node(&node.rpc_client().unwrap(), node.get_node_public_key())
-            .await
-            .unwrap();
+    let response = FleekApiClient::node_has_sufficient_stake(
+        &node.rpc_client().unwrap(),
+        node.get_node_public_key(),
+    )
+    .await
+    .unwrap();
     assert!(response);
 
     network.shutdown().await;

--- a/core/syncronizer/src/syncronizer.rs
+++ b/core/syncronizer/src/syncronizer.rs
@@ -104,8 +104,8 @@ impl<C: NodeComponents> Syncronizer<C> {
         // The rpc calls are using a lot of clones. This is necessary because the futures are
         // passed into a thread, and thus need to satisfy the 'static lifetime.
 
-        // Check if node is staked.
-        let is_valid = rpc::sync_call(rpc::check_is_valid_node(
+        // Check if node has sufficient stake.
+        let is_valid = rpc::sync_call(rpc::check_if_node_has_sufficient_stake(
             our_public_key,
             genesis_committee.to_vec(),
         ))
@@ -226,7 +226,7 @@ impl<C: NodeComponents> SyncronizerInner<C> {
                     // has already been applied, otherwise we skip it.
                     // At this point the genesis should always already have been applied, but we keep the check anyway.
                     if !cfg!(debug_assertions) && self.query_runner.has_genesis() {
-                        if !self.query_runner.is_valid_node(&self.our_public_key) {
+                        if !self.query_runner.has_sufficient_stake(&self.our_public_key) {
                             println!("The node doesn't have enough stake to participate in the network.");
                             std::process::exit(1);
                         }

--- a/core/types/src/response.rs
+++ b/core/types/src/response.rs
@@ -151,6 +151,7 @@ pub enum ExecutionError {
     OnlyGovernance,
     InvalidServiceId,
     InsufficientStake,
+    NodeNotParticipating,
     LockExceededMaxStakeLockTime,
     LockedTokensUnstakeForbidden,
     EpochAlreadyChanged,


### PR DESCRIPTION
This PR does a few things:
- Update `is_valid_node` to check for `staked + locked >= min_stake` instead of just `staked >= min_stake`, and rename it to `has_sufficient_stake`
- On unstake, set participation to `OptedOut` if the node no longer has sufficient unlocked stake so that participation=False is set on the next epoch change
- On opt-in, check for unlocked stake only (not locked stake)