### PR TITLE
feat(app): track node registry changes

### DIFF
--- a/core/application/src/state/executor/epoch_change.rs
+++ b/core/application/src/state/executor/epoch_change.rs
@@ -710,6 +710,7 @@ impl<B: Backend> StateExecutor<B> {
             members: committee,
             epoch_end_timestamp,
             active_node_set: active_nodes,
+            node_registry_changes: Default::default(),
         }
     }
 

--- a/core/types/src/state.rs
+++ b/core/types/src/state.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 use sha3::{Digest, Sha3_256};
 
 use super::ReputationMeasurements;
+use crate::NodeRegistryChanges;
 
 /// The Id of a Service
 pub type ServiceId = u32;
@@ -539,6 +540,7 @@ pub struct Committee {
     pub ready_to_change: Vec<NodeIndex>,
     pub epoch_end_timestamp: u64,
     pub active_node_set: Vec<NodeIndex>,
+    pub node_registry_changes: NodeRegistryChanges,
 }
 
 impl TranscriptBuilderInput for Service {


### PR DESCRIPTION
Track node registry changes on the `BlockExecutionResponse` by recording it on the `Committee` during execution. For this PR, record `NodeRegistryChange::New` when applying genesis and when creating a new node during `stake`. This is in prep for committee beacon slashing, where `NodeRegistryChange::Slashed` will be added and used.