### PR TITLE
chore(utils/tx): retry with same nonce on forwarder errors

### DIFF
--- a/core/application/src/tests/staking.rs
+++ b/core/application/src/tests/staking.rs
@@ -786,6 +786,7 @@ async fn test_withdraw_unstaked_works_properly() {
             new_block_interval: Duration::from_millis(0),
             transactions_to_lose: Default::default(),
             block_buffering_interval: Duration::from_millis(0),
+            forwarder_transaction_to_error: Default::default(),
         })
         .with_committee_nodes::<TestFullNodeComponentsWithMockConsensus>(4)
         .await

--- a/core/archive/src/tests.rs
+++ b/core/archive/src/tests.rs
@@ -51,6 +51,7 @@ async fn get_node() -> Node<TestBinding> {
                 transactions_to_lose: Default::default(),
                 new_block_interval: Duration::from_secs(0),
                 block_buffering_interval: Duration::from_secs(0),
+                forwarder_transaction_to_error: Default::default(),
             }),
     )
     .unwrap();

--- a/core/committee-beacon/tests/tests.rs
+++ b/core/committee-beacon/tests/tests.rs
@@ -510,6 +510,7 @@ async fn build_network(options: BuildNetworkOptions) -> Result<TestNetwork> {
             new_block_interval: Duration::from_millis(0),
             transactions_to_lose: Default::default(),
             block_buffering_interval: options.consensus_buffer_interval,
+            forwarder_transaction_to_error: Default::default(),
         })
         .with_committee_beacon_config(committee_beacon_config.clone())
         .with_committee_nodes::<TestFullNodeComponentsWithMockConsensus>(options.committee_nodes)

--- a/core/dack-aggregator/src/tests.rs
+++ b/core/dack-aggregator/src/tests.rs
@@ -102,6 +102,7 @@ async fn init_aggregator(temp_dir: &TempDir) -> Node<TestBinding> {
                         transactions_to_lose: HashSet::new(),
                         new_block_interval: Duration::from_secs(5),
                         block_buffering_interval: Duration::from_secs(0),
+                        forwarder_transaction_to_error: HashSet::new(),
                     })
                     .with::<DeliveryAcknowledgmentAggregator<TestBinding>>(Config {
                         submit_interval: Duration::from_secs(1),

--- a/core/indexer/src/tests.rs
+++ b/core/indexer/src/tests.rs
@@ -112,6 +112,7 @@ async fn test_submission() {
                         transactions_to_lose: HashSet::new(),
                         new_block_interval: Duration::from_secs(5),
                         block_buffering_interval: Duration::from_secs(0),
+                        forwarder_transaction_to_error: HashSet::new(),
                     }),
             )
             .with(keystore),

--- a/core/origin-demuxer/src/tests.rs
+++ b/core/origin-demuxer/src/tests.rs
@@ -141,6 +141,7 @@ async fn create_app_state(temp_dir: &TempDir) -> AppState {
                         transactions_to_lose: HashSet::new(),
                         new_block_interval: Duration::from_secs(5),
                         block_buffering_interval: Duration::from_secs(0),
+                        forwarder_transaction_to_error: HashSet::new(),
                     }),
             )
             .with(keystore),

--- a/core/origin-http/src/tests.rs
+++ b/core/origin-http/src/tests.rs
@@ -130,6 +130,7 @@ async fn create_app_state(temp_dir: &TempDir) -> AppState {
                         transactions_to_lose: HashSet::new(),
                         new_block_interval: Duration::from_secs(5),
                         block_buffering_interval: Duration::from_secs(0),
+                        forwarder_transaction_to_error: HashSet::new(),
                     }),
             )
             .with(keystore),

--- a/core/origin-ipfs/src/tests.rs
+++ b/core/origin-ipfs/src/tests.rs
@@ -132,6 +132,7 @@ async fn create_app_state(temp_dir: &TempDir) -> AppState {
                         transactions_to_lose: HashSet::new(),
                         new_block_interval: Duration::from_secs(5),
                         block_buffering_interval: Duration::from_secs(0),
+                        forwarder_transaction_to_error: HashSet::new(),
                     }),
             )
             .with(keystore),

--- a/core/signer/src/tests.rs
+++ b/core/signer/src/tests.rs
@@ -274,6 +274,7 @@ impl<C: NodeComponents> TestNode<C> {
                         transactions_to_lose: HashSet::new(),
                         new_block_interval: Duration::from_secs(0),
                         block_buffering_interval: Duration::from_secs(0),
+                        forwarder_transaction_to_error: HashSet::new(),
                     }),
             ),
         )

--- a/core/test-utils/src/e2e/network_builder.rs
+++ b/core/test-utils/src/e2e/network_builder.rs
@@ -49,6 +49,7 @@ impl TestNetworkBuilder {
             new_block_interval: Duration::from_secs(0),
             transactions_to_lose: Default::default(),
             block_buffering_interval: Duration::from_millis(0),
+            forwarder_transaction_to_error: Default::default(),
         })
     }
 

--- a/core/types/src/transaction.rs
+++ b/core/types/src/transaction.rs
@@ -41,6 +41,8 @@ pub type ChainId = u32;
 
 pub type TxHash = [u8; 32];
 
+pub type Nonce = u64;
+
 // TODO: Change this to capital and non-abrv version.
 const FN_TXN_PAYLOAD_DOMAIN: &str = "fleek_network_txn_payload";
 
@@ -200,6 +202,13 @@ impl TransactionRequest {
             }
         } else {
             None
+        }
+    }
+
+    pub fn nonce(&self) -> Nonce {
+        match self {
+            Self::UpdateRequest(payload) => payload.payload.nonce,
+            Self::EthereumRequest(payload) => payload.nonce.as_u64(),
         }
     }
 }

--- a/core/utils/src/transaction/nonce.rs
+++ b/core/utils/src/transaction/nonce.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use lightning_interfaces::types::Nonce;
 use tokio::sync::RwLock;
 
 #[derive(Clone)]
@@ -8,7 +9,7 @@ pub(crate) struct NonceState {
 }
 
 impl NonceState {
-    pub fn new(base: u64) -> Self {
+    pub fn new(base: Nonce) -> Self {
         Self {
             inner: Arc::new(RwLock::new(NonceStateInner {
                 base,
@@ -17,31 +18,31 @@ impl NonceState {
         }
     }
 
-    pub async fn update(&self, base: u64) {
+    pub async fn update(&self, base: Nonce) {
         let mut inner = self.inner.write().await;
         inner.base = base;
         inner.next = base + 1;
     }
 
-    pub async fn get_next_and_increment(&self) -> u64 {
+    pub async fn get_next_and_increment(&self) -> Nonce {
         let mut inner = self.inner.write().await;
         let next = inner.next;
         inner.next += 1;
         next
     }
 
-    pub async fn get_next(&self) -> u64 {
+    pub async fn get_next(&self) -> Nonce {
         let inner = self.inner.read().await;
         inner.next
     }
 
-    pub async fn get_base(&self) -> u64 {
+    pub async fn get_base(&self) -> Nonce {
         let inner = self.inner.read().await;
         inner.base
     }
 }
 
 pub(crate) struct NonceStateInner {
-    base: u64,
-    next: u64,
+    base: Nonce,
+    next: Nonce,
 }


### PR DESCRIPTION
When a forwarder error happens, we can retry with the same nonce instead of incrementing, since the transaction didn't even make it to the mempool.