### PR TITLE
feat: committee selection beacon slashing

### DIFF
--- a/core/application/networks/localnet-example/genesis.toml
+++ b/core/application/networks/localnet-example/genesis.toml
@@ -23,6 +23,7 @@ topology_target_k = 8
 topology_min_nodes = 16
 committee_selection_beacon_commit_phase_duration = 10
 committee_selection_beacon_reveal_phase_duration = 10
+committee_selection_beacon_non_reveal_slash_amount = 1000
 
 [[node_info]]
 owner = "0x959807B8D94B324A74117956731F09E2893aCd72"

--- a/core/application/networks/testnet-stable/genesis.toml
+++ b/core/application/networks/testnet-stable/genesis.toml
@@ -36,6 +36,10 @@ committee_selection_beacon_commit_phase_duration = 600
 # and starting with a long duration for safety since non-revealing nodes will be slashed.
 committee_selection_beacon_reveal_phase_duration = 12000
 
+# Amount of stake to slash for non-revealing nodes.
+# 1000 is 100% of the minimum stake.
+committee_selection_beacon_non_reveal_slash_amount = 1000
+
 
 [[node_info]]
 owner = "0x2a8cf657769c264b0c7f88e3a716afdeaec1c318"

--- a/core/application/src/env.rs
+++ b/core/application/src/env.rs
@@ -334,6 +334,12 @@ impl ApplicationEnv {
                     genesis.committee_selection_beacon_reveal_phase_duration,
                 ),
             );
+            param_table.insert(
+                ProtocolParamKey::CommitteeSelectionBeaconNonRevealSlashAmount,
+                ProtocolParamValue::CommitteeSelectionBeaconNonRevealSlashAmount(
+                    genesis.committee_selection_beacon_non_reveal_slash_amount,
+                ),
+            );
 
             let epoch_end: u64 = genesis.epoch_time + genesis.epoch_start;
             let mut committee_members = Vec::with_capacity(4);

--- a/core/application/src/network.rs
+++ b/core/application/src/network.rs
@@ -27,11 +27,11 @@ mod tests {
 
     #[test]
     fn test_localnet_example_genesis() {
-        assert!(Network::LocalnetExample.genesis().is_ok());
+        Network::LocalnetExample.genesis().unwrap();
     }
 
     #[test]
     fn test_testnet_stable_genesis() {
-        assert!(Network::TestnetStable.genesis().is_ok());
+        Network::TestnetStable.genesis().unwrap();
     }
 }

--- a/core/application/src/state/executor/epoch_change.rs
+++ b/core/application/src/state/executor/epoch_change.rs
@@ -319,6 +319,9 @@ impl<B: Backend> StateExecutor<B> {
             // Reset the committee selection beacon.
             self.clear_committee_selection_beacons();
 
+            // Clear the non-revealing nodes table from the previous round.
+            self.clear_committee_selection_beacon_non_revealing_node();
+
             // Execute the epoch change.
             self.execute_epoch_change(epoch, committee, beacons);
 
@@ -457,7 +460,10 @@ impl<B: Backend> StateExecutor<B> {
             self.set_committee_selection_beacon_round(round + 1);
 
             // Clear the beacon state.
-            self.committee_selection_beacon.clear();
+            self.clear_committee_selection_beacons();
+
+            // Clear the non-revealing nodes table from the previous round.
+            self.clear_committee_selection_beacon_non_revealing_node();
         }
 
         // Return success.
@@ -532,9 +538,6 @@ impl<B: Backend> StateExecutor<B> {
         self.set_committee_selection_beacon_round(round + 1);
 
         // Save non-revealing nodes to state so we can reject any commits in the next round.
-        // Clear existing non-revealing nodes table first.
-        self.committee_selection_beacon_non_revealing_node.clear();
-        // TODO(snormore): Do we need to clear this in other places like on epoch change?
         let beacons = self.committee_selection_beacon.as_map();
         let non_revealing_nodes = beacons
             .iter()
@@ -615,6 +618,10 @@ impl<B: Backend> StateExecutor<B> {
 
     fn clear_committee_selection_beacons(&self) {
         self.committee_selection_beacon.clear();
+    }
+
+    fn clear_committee_selection_beacon_non_revealing_node(&self) {
+        self.committee_selection_beacon_non_revealing_node.clear();
     }
 
     fn get_committee_selection_beacon_round(&self) -> Option<u64> {

--- a/core/application/src/state/query.rs
+++ b/core/application/src/state/query.rs
@@ -78,7 +78,7 @@ pub struct QueryRunner {
             Option<CommitteeSelectionBeaconReveal>,
         ),
     >,
-    _committee_selection_beacon_non_revealing_node: ResolvedTableReference<NodeIndex, ()>,
+    committee_selection_beacon_non_revealing_node: ResolvedTableReference<NodeIndex, ()>,
 }
 
 impl QueryRunner {
@@ -120,7 +120,7 @@ impl SyncQueryRunnerInterface for QueryRunner {
                 CommitteeSelectionBeaconCommit,
                 Option<CommitteeSelectionBeaconReveal>,
             )>("committee_selection_beacon"),
-            _committee_selection_beacon_non_revealing_node: atomo
+            committee_selection_beacon_non_revealing_node: atomo
                 .resolve::<NodeIndex, ()>("committee_selection_beacon_non_revealing_node"),
 
             inner: atomo,
@@ -235,6 +235,18 @@ impl SyncQueryRunnerInterface for QueryRunner {
     )> {
         self.inner
             .run(|ctx| self.committee_selection_beacon.get(ctx).get(node))
+    }
+
+    fn get_committee_selection_beacon_non_revealing_nodes(&self) -> Vec<NodeIndex> {
+        self.inner
+            .run(|ctx| {
+                self.committee_selection_beacon_non_revealing_node
+                    .get(ctx)
+                    .as_map()
+            })
+            .keys()
+            .cloned()
+            .collect()
     }
 
     fn get_service_info(&self, id: &ServiceId) -> Option<Service> {

--- a/core/application/src/tests/utils.rs
+++ b/core/application/src/tests/utils.rs
@@ -957,6 +957,8 @@ pub struct TestNetworkBuilder {
     commit_phase_duration: u64,
     reveal_phase_duration: u64,
     stake_lock_time: u64,
+    non_reveal_slash_amount: u64,
+    min_stake: u64,
     genesis_mutator: Option<GenesisMutator>,
 }
 
@@ -976,6 +978,8 @@ impl TestNetworkBuilder {
             commit_phase_duration: 2,
             reveal_phase_duration: 2,
             stake_lock_time: 5,
+            non_reveal_slash_amount: 1000,
+            min_stake: 1000,
             genesis_mutator: None,
         }
     }
@@ -1002,6 +1006,16 @@ impl TestNetworkBuilder {
 
     pub fn with_stake_lock_time(mut self, stake_lock_time: u64) -> Self {
         self.stake_lock_time = stake_lock_time;
+        self
+    }
+
+    pub fn with_non_reveal_slash_amount(mut self, non_reveal_slash_amount: u64) -> Self {
+        self.non_reveal_slash_amount = non_reveal_slash_amount;
+        self
+    }
+
+    pub fn with_min_stake(mut self, min_stake: u64) -> Self {
+        self.min_stake = min_stake;
         self
     }
 
@@ -1033,14 +1047,19 @@ impl TestNetworkBuilder {
 
         let chain_id = 1337;
         let stake_lock_time = self.stake_lock_time;
+        let min_stake = self.min_stake;
         let commit_phase_duration = self.commit_phase_duration;
         let reveal_phase_duration = self.reveal_phase_duration;
+        let non_reveal_slash_amount = self.non_reveal_slash_amount;
         let mut builder = TestGenesisBuilder::new()
             .with_chain_id(chain_id)
             .with_mutator(Arc::new(move |genesis: &mut Genesis| {
                 genesis.lock_time = stake_lock_time;
+                genesis.min_stake = min_stake;
                 genesis.committee_selection_beacon_commit_phase_duration = commit_phase_duration;
                 genesis.committee_selection_beacon_reveal_phase_duration = reveal_phase_duration;
+                genesis.committee_selection_beacon_non_reveal_slash_amount =
+                    non_reveal_slash_amount;
             }));
 
         let mut nodes = vec![];

--- a/core/application/src/tests/utils.rs
+++ b/core/application/src/tests/utils.rs
@@ -424,6 +424,7 @@ pub(crate) fn test_genesis() -> Genesis {
         topology_min_nodes: 16,
         committee_selection_beacon_commit_phase_duration: 10,
         committee_selection_beacon_reveal_phase_duration: 10,
+        committee_selection_beacon_non_reveal_slash_amount: 1000,
     }
 }
 

--- a/core/cli/tests/checkpoint.rs
+++ b/core/cli/tests/checkpoint.rs
@@ -150,7 +150,7 @@ async fn test_node_load_checkpoint_start_ready_shutdown_iterations() {
 
         // Start the node and wait for it to be ready.
         node.start().await;
-        node.wait_for_ready(Some(Duration::from_secs(5)))
+        node.wait_for_ready(Some(Duration::from_secs(20)))
             .await
             .unwrap();
 
@@ -204,7 +204,7 @@ async fn wait_for_database_locks(config: &TomlConfigProvider<FullNodeComponents>
     if let Some(path) = app_db_path {
         wait_for_file_to_close(
             &path.join("LOCK"),
-            Duration::from_secs(5),
+            Duration::from_secs(10),
             Duration::from_millis(100),
         )
         .await?;
@@ -213,7 +213,7 @@ async fn wait_for_database_locks(config: &TomlConfigProvider<FullNodeComponents>
     // Wait for the narwhal db lock file to be released.
     wait_for_file_to_close(
         &consensus_db_path.join("0/LOCK"),
-        Duration::from_secs(5),
+        Duration::from_secs(10),
         Duration::from_millis(100),
     )
     .await?;

--- a/core/cli/tests/checkpoint.rs
+++ b/core/cli/tests/checkpoint.rs
@@ -204,7 +204,7 @@ async fn wait_for_database_locks(config: &TomlConfigProvider<FullNodeComponents>
     if let Some(path) = app_db_path {
         wait_for_file_to_close(
             &path.join("LOCK"),
-            Duration::from_secs(10),
+            Duration::from_secs(5),
             Duration::from_millis(100),
         )
         .await?;
@@ -212,8 +212,8 @@ async fn wait_for_database_locks(config: &TomlConfigProvider<FullNodeComponents>
 
     // Wait for the narwhal db lock file to be released.
     wait_for_file_to_close(
-        &consensus_db_path.join("0/LOCK"),
-        Duration::from_secs(10),
+        &consensus_db_path.join("0-0/LOCK"),
+        Duration::from_secs(5),
         Duration::from_millis(100),
     )
     .await?;

--- a/core/committee-beacon/src/database.rs
+++ b/core/committee-beacon/src/database.rs
@@ -1,5 +1,9 @@
 use fxhash::FxHashMap;
-use lightning_interfaces::types::{CommitteeSelectionBeaconCommit, CommitteeSelectionBeaconReveal};
+use lightning_interfaces::types::{
+    CommitteeSelectionBeaconCommit,
+    CommitteeSelectionBeaconReveal,
+    Epoch,
+};
 
 use crate::config::CommitteeBeaconDatabaseConfig;
 
@@ -21,15 +25,16 @@ pub trait CommitteeBeaconDatabase: Clone + Send + Sync {
     /// Get the query instance for this database.
     fn query(&self) -> Self::Query;
 
-    /// Set the beacon reveal value for a given commit.
+    /// Set the beacon reveal value for a given epoch and commit.
     fn set_beacon(
         &self,
+        epoch: Epoch,
         commit: CommitteeSelectionBeaconCommit,
         reveal: CommitteeSelectionBeaconReveal,
     );
 
-    /// Clear beacons.
-    fn clear_beacons(&self);
+    /// Clear beacons before a given epoch.
+    fn clear_beacons_before_epoch(&self, epoch: Epoch);
 }
 
 /// A trait for a committee beacon database query, encapsulating the database query operations that
@@ -41,11 +46,12 @@ pub trait CommitteeBeaconDatabaseQuery {
     /// Get beacon for a given commit.
     fn get_beacon(
         &self,
+        epoch: Epoch,
         commit: CommitteeSelectionBeaconCommit,
     ) -> Option<CommitteeSelectionBeaconReveal>;
 
     /// Get all the locally stored beacons.
     fn get_beacons(
         &self,
-    ) -> FxHashMap<CommitteeSelectionBeaconCommit, CommitteeSelectionBeaconReveal>;
+    ) -> FxHashMap<(Epoch, CommitteeSelectionBeaconCommit), CommitteeSelectionBeaconReveal>;
 }

--- a/core/committee-beacon/src/listener.rs
+++ b/core/committee-beacon/src/listener.rs
@@ -172,8 +172,18 @@ impl<C: NodeComponents> CommitteeBeaconListener<C> {
             current_block
         );
 
-        // TODO(snormore): If we were a non-revealing node in the previous epoch, we should not
-        // commit, it will just be rejected/reverted.
+        // If this node was a recent non-revealing node, skip the commit phase, since it will be
+        // rejected/reverted anyway.
+        let non_revealing_nodes = self
+            .app_query
+            .get_committee_selection_beacon_non_revealing_nodes();
+        if non_revealing_nodes.contains(&self.node_index) {
+            tracing::debug!(
+                "node {} is non-revealing in previous epoch, skipping commit",
+                self.node_index
+            );
+            return Ok(());
+        }
 
         // If this is the first block outside of the commit phase range, execute a commit timeout
         // transaction and return.

--- a/core/committee-beacon/src/query.rs
+++ b/core/committee-beacon/src/query.rs
@@ -1,5 +1,9 @@
 use fxhash::FxHashMap;
-use lightning_interfaces::types::{CommitteeSelectionBeaconCommit, CommitteeSelectionBeaconReveal};
+use lightning_interfaces::types::{
+    CommitteeSelectionBeaconCommit,
+    CommitteeSelectionBeaconReveal,
+    Epoch,
+};
 use lightning_interfaces::CommitteeBeaconQueryInterface;
 
 use crate::database::CommitteeBeaconDatabaseQuery;
@@ -19,7 +23,7 @@ impl CommitteeBeaconQuery {
 impl CommitteeBeaconQueryInterface for CommitteeBeaconQuery {
     fn get_beacons(
         &self,
-    ) -> FxHashMap<CommitteeSelectionBeaconCommit, CommitteeSelectionBeaconReveal> {
+    ) -> FxHashMap<(Epoch, CommitteeSelectionBeaconCommit), CommitteeSelectionBeaconReveal> {
         self.db.get_beacons()
     }
 }

--- a/core/committee-beacon/src/rocks/query.rs
+++ b/core/committee-beacon/src/rocks/query.rs
@@ -1,9 +1,13 @@
 use atomo::{Atomo, DefaultSerdeBackend, QueryPerm};
 use atomo_rocks::RocksBackend;
 use fxhash::FxHashMap;
-use lightning_interfaces::types::{CommitteeSelectionBeaconCommit, CommitteeSelectionBeaconReveal};
+use lightning_interfaces::types::{
+    CommitteeSelectionBeaconCommit,
+    CommitteeSelectionBeaconReveal,
+    Epoch,
+};
 
-use super::database::BEACONS_TABLE;
+use super::database::{BeaconsTableKey, BEACONS_TABLE};
 use crate::database::CommitteeBeaconDatabaseQuery;
 
 /// A committee beacon database query type that uses RocksDB as the underlying datastore.
@@ -21,26 +25,23 @@ impl RocksCommitteeBeaconDatabaseQuery {
 impl CommitteeBeaconDatabaseQuery for RocksCommitteeBeaconDatabaseQuery {
     fn get_beacon(
         &self,
+        epoch: Epoch,
         commit: CommitteeSelectionBeaconCommit,
     ) -> Option<CommitteeSelectionBeaconReveal> {
         self.atomo.query().run(|ctx| {
-            let table = ctx
-                .get_table::<CommitteeSelectionBeaconCommit, CommitteeSelectionBeaconReveal>(
-                    BEACONS_TABLE,
-                );
+            let table =
+                ctx.get_table::<BeaconsTableKey, CommitteeSelectionBeaconReveal>(BEACONS_TABLE);
 
-            table.get(commit)
+            table.get((epoch, commit))
         })
     }
 
     fn get_beacons(
         &self,
-    ) -> FxHashMap<CommitteeSelectionBeaconCommit, CommitteeSelectionBeaconReveal> {
+    ) -> FxHashMap<(Epoch, CommitteeSelectionBeaconCommit), CommitteeSelectionBeaconReveal> {
         self.atomo.query().run(|ctx| {
-            let table = ctx
-                .get_table::<CommitteeSelectionBeaconCommit, CommitteeSelectionBeaconReveal>(
-                    BEACONS_TABLE,
-                );
+            let table =
+                ctx.get_table::<BeaconsTableKey, CommitteeSelectionBeaconReveal>(BEACONS_TABLE);
 
             table.as_map()
         })

--- a/core/committee-beacon/src/rocks/tests.rs
+++ b/core/committee-beacon/src/rocks/tests.rs
@@ -15,20 +15,21 @@ fn test_set_and_get_beacon() {
         path: tempdir.path().to_path_buf().try_into().unwrap(),
     });
     let query = db.query();
+    let epoch = 1;
 
     // Set a beacon and check that it's retrievable.
     let (commit, reveal) = generate_random_beacon();
-    db.set_beacon(commit, reveal);
-    assert_eq!(query.get_beacon(commit), Some(reveal));
+    db.set_beacon(epoch, commit, reveal);
+    assert_eq!(query.get_beacon(epoch, commit), Some(reveal));
 
     // Set the same beacon again and check that it remains the same.
-    db.set_beacon(commit, reveal);
-    assert_eq!(query.get_beacon(commit), Some(reveal));
+    db.set_beacon(epoch, commit, reveal);
+    assert_eq!(query.get_beacon(epoch, commit), Some(reveal));
 
     // Set the same beacon commit with a different reveal and check that it overwrites.
     let (_, new_reveal) = generate_random_beacon();
-    db.set_beacon(commit, new_reveal);
-    assert_eq!(query.get_beacon(commit), Some(new_reveal));
+    db.set_beacon(epoch, commit, new_reveal);
+    assert_eq!(query.get_beacon(epoch, commit), Some(new_reveal));
     assert_ne!(new_reveal, reveal);
 }
 
@@ -39,17 +40,18 @@ fn test_get_beacons() {
         path: tempdir.path().to_path_buf().try_into().unwrap(),
     });
     let query = db.query();
+    let epoch = 1;
 
     // Set some beacons.
     let (commit1, reveal1) = generate_random_beacon();
     let (commit2, reveal2) = generate_random_beacon();
-    db.set_beacon(commit1, reveal1);
-    db.set_beacon(commit2, reveal2);
+    db.set_beacon(epoch, commit1, reveal1);
+    db.set_beacon(epoch, commit2, reveal2);
 
     // Check that we get all the beacons.
     assert_eq!(
         query.get_beacons(),
-        FxHashMap::from_iter([(commit1, reveal1), (commit2, reveal2)])
+        FxHashMap::from_iter([((epoch, commit1), reveal1), ((epoch, commit2), reveal2)])
     );
 }
 
@@ -60,17 +62,25 @@ fn test_clear_beacons() {
         path: tempdir.path().to_path_buf().try_into().unwrap(),
     });
     let query = db.query();
+    let epoch = 1;
 
     // Set some beacons.
     let (commit1, reveal1) = generate_random_beacon();
     let (commit2, reveal2) = generate_random_beacon();
-    db.set_beacon(commit1, reveal1);
-    db.set_beacon(commit2, reveal2);
+    db.set_beacon(epoch, commit1, reveal1);
+    db.set_beacon(epoch, commit2, reveal2);
 
-    // Clear the beacons and check that they're gone.
-    db.clear_beacons();
-    assert_eq!(query.get_beacon(commit1), None);
-    assert_eq!(query.get_beacon(commit2), None);
+    let (commit1, reveal1) = generate_random_beacon();
+    let (commit2, reveal2) = generate_random_beacon();
+    db.set_beacon(epoch + 1, commit1, reveal1);
+    db.set_beacon(epoch + 1, commit2, reveal2);
+
+    // Clear some beacons and check that they're gone.
+    db.clear_beacons_before_epoch(epoch);
+    assert_eq!(query.get_beacon(epoch, commit1), None);
+    assert_eq!(query.get_beacon(epoch, commit2), None);
+    assert_eq!(query.get_beacon(epoch + 1, commit1), Some(reveal1));
+    assert_eq!(query.get_beacon(epoch + 1, commit2), Some(reveal2));
 }
 
 fn generate_random_beacon() -> (

--- a/core/committee-beacon/src/timer.rs
+++ b/core/committee-beacon/src/timer.rs
@@ -109,7 +109,7 @@ impl<C: NodeComponents> CommitteeBeaconTimer<C> {
                             }
                         },
                         Err(e) => {
-                            tracing::error!("ignoring transaction client error: {:?}", e);
+                            tracing::info!("ignoring transaction client error: {:?}", e);
                         },
                     }
 

--- a/core/committee-beacon/tests/tests.rs
+++ b/core/committee-beacon/tests/tests.rs
@@ -86,7 +86,9 @@ async fn test_epoch_change_single_node() {
         beacons
     );
 
-    // Check that the local database beacons are eventually cleared.
+    // Change epoch and check that the local database beacons are eventually cleared.
+    network.wait_for_epoch_change(new_epoch).await.unwrap();
+    network.change_epoch().await.unwrap();
     poll_until(
         || async {
             node.committee_beacon()
@@ -147,7 +149,9 @@ async fn test_epoch_change_multiple_nodes() {
         );
     }
 
-    // Check that the local database beacons are eventually cleared.
+    // Change epoch and check that the local database beacons are eventually cleared.
+    network.wait_for_epoch_change(epoch).await.unwrap();
+    network.change_epoch().await.unwrap();
     poll_until(
         || async {
             node.committee_beacon()

--- a/core/committee-beacon/tests/tests.rs
+++ b/core/committee-beacon/tests/tests.rs
@@ -1157,7 +1157,7 @@ where
                 Err(PollUntilError::ConditionNotSatisfied)
             }
         },
-        Duration::from_secs(15),
+        Duration::from_secs(30),
         Duration::from_millis(100),
     )
     .await

--- a/core/consensus/src/execution/transaction_store.rs
+++ b/core/consensus/src/execution/transaction_store.rs
@@ -93,11 +93,14 @@ impl<T: BroadcastEventInterface<PubSubMsg>> TransactionStore<T> {
         self.store_attestation_internal(self.next_pointer(), digest, node_index, Some(event));
     }
 
-    // When the epoch changes, the parcels from the current epochs become
-    // the parcels from the previous epoch.
-    // The parcels from the previous epoch are garbage collected, and the parcels from
-    // the next epoch become the parcels from the current epoch (after validating them).
-    pub fn change_epoch(&mut self, committee: &[NodeIndex]) {
+    /// Change the committee.
+    ///
+    /// When the committee is changed for across epoch eras and epochs, the parcels from the current
+    /// become the parcels from the previous.
+    ///
+    /// The parcels from the previous are garbage collected, and the parcels from the next becom
+    /// ethe parcels from the current after validating them.
+    pub fn change_committee(&mut self, committee: &[NodeIndex]) {
         // Verify that the parcels/attestations from the next epoch were send by committee members.
         // Remove invalid parcels/attestations from the hash map.
         let next_pointer = self.next_pointer();

--- a/core/consensus/src/execution/transaction_store.rs
+++ b/core/consensus/src/execution/transaction_store.rs
@@ -93,14 +93,11 @@ impl<T: BroadcastEventInterface<PubSubMsg>> TransactionStore<T> {
         self.store_attestation_internal(self.next_pointer(), digest, node_index, Some(event));
     }
 
-    /// Change the committee.
-    ///
-    /// When the committee is changed for across epoch eras and epochs, the parcels from the current
-    /// become the parcels from the previous.
-    ///
-    /// The parcels from the previous are garbage collected, and the parcels from the next becom
-    /// ethe parcels from the current after validating them.
-    pub fn change_committee(&mut self, committee: &[NodeIndex]) {
+    // When the epoch changes, the parcels from the current epochs become
+    // the parcels from the previous epoch.
+    // The parcels from the previous epoch are garbage collected, and the parcels from
+    // the next epoch become the parcels from the current epoch (after validating them).
+    pub fn change_epoch(&mut self, committee: &[NodeIndex]) {
         // Verify that the parcels/attestations from the next epoch were send by committee members.
         // Remove invalid parcels/attestations from the hash map.
         let next_pointer = self.next_pointer();

--- a/core/consensus/src/execution/worker.rs
+++ b/core/consensus/src/execution/worker.rs
@@ -15,6 +15,7 @@ use tokio::sync::mpsc::Receiver;
 use tokio::sync::{mpsc, oneshot, Notify};
 use tokio::task::JoinHandle;
 use tracing::{error, info};
+use types::BlockExecutionResponse;
 
 use super::parcel::{AuthenticStampedParcel, CommitteeAttestation, Digest};
 use super::state::FilteredConsensusOutput;
@@ -249,7 +250,9 @@ async fn handle_consensus_output<P: PubSub<PubSubMsg>, Q: SyncQueryRunnerInterfa
         sub_dag_round: consensus_output.sub_dag_round,
     };
 
-    let epoch_changed = submit_batch(
+    let epoch_era_before_execution = ctx.query_runner.get_epoch_era();
+
+    let response = submit_batch(
         ctx,
         consensus_output.transactions,
         parcel.to_digest(),
@@ -273,7 +276,16 @@ async fn handle_consensus_output<P: PubSub<PubSubMsg>, Q: SyncQueryRunnerInterfa
         .store_parcel(parcel, ctx.our_index, msg_digest.ok());
     // No need to store the attestation we have already executed it
 
-    if epoch_changed {
+    // Epoch era is changed when the committee is changed mid-epoch.
+    let is_epoch_era_changed = epoch_era_before_execution != ctx.query_runner.get_epoch_era();
+
+    if response.change_epoch || is_epoch_era_changed {
+        if response.change_epoch {
+            tracing::info!("reconfiguring after epoch change");
+        }
+        if is_epoch_era_changed {
+            tracing::info!("reconfiguring after epoch era change");
+        }
         ctx.reconfigure_notify.notify_waiters();
 
         ctx.committee = ctx.query_runner.get_committee_members_by_index();
@@ -286,7 +298,7 @@ async fn handle_consensus_output<P: PubSub<PubSubMsg>, Q: SyncQueryRunnerInterfa
             .unwrap_or(u32::MAX);
         ctx.on_committee = ctx.committee.contains(&ctx.our_index);
 
-        ctx.txn_store.change_epoch(&ctx.committee);
+        ctx.txn_store.change_committee(&ctx.committee);
     }
 }
 
@@ -298,7 +310,7 @@ async fn submit_batch<P: PubSub<PubSubMsg>, Q: SyncQueryRunnerInterface, NE: Emi
     digest: Digest,
     sub_dag_index: u64,
     sub_dag_round: u64,
-) -> bool {
+) -> BlockExecutionResponse {
     let transactions = payload
         .into_iter()
         .filter_map(|txn| {
@@ -336,12 +348,11 @@ async fn submit_batch<P: PubSub<PubSubMsg>, Q: SyncQueryRunnerInterface, NE: Emi
             .collect(),
     );
 
-    let change_epoch = response.change_epoch;
     let previous_state_root = response.previous_state_root.into();
     let new_state_root = response.new_state_root.into();
-    ctx.notifier.new_block(archive_block, response);
+    ctx.notifier.new_block(archive_block, response.clone());
 
-    if change_epoch {
+    if response.change_epoch {
         let epoch_number = ctx.query_runner.get_current_epoch();
         let epoch_hash = ctx
             .query_runner
@@ -358,7 +369,7 @@ async fn submit_batch<P: PubSub<PubSubMsg>, Q: SyncQueryRunnerInterface, NE: Emi
         );
     }
 
-    change_epoch
+    response
 }
 
 // This function is called when the current node receives a consensus event via broadcast.
@@ -534,7 +545,7 @@ async fn execute_digest<P: PubSub<PubSubMsg>, Q: SyncQueryRunnerInterface, NE: E
                     .unwrap_or(u32::MAX);
                 ctx.on_committee = ctx.committee.contains(&ctx.our_index);
                 ctx.reconfigure_notify.notify_waiters();
-                ctx.txn_store.change_epoch(&ctx.committee);
+                ctx.txn_store.change_committee(&ctx.committee);
             }
         },
         Err(not_executed) => {
@@ -654,7 +665,8 @@ async fn try_execute_chain<P: PubSub<PubSubMsg>, Q: SyncQueryRunnerInterface, NE
 
             // We connected the chain now execute all the transactions
             for (batch, sub_dag_index, sub_dag_round, digest) in txn_chain {
-                if submit_batch(ctx, batch, digest, sub_dag_index, sub_dag_round).await {
+                let response = submit_batch(ctx, batch, digest, sub_dag_index, sub_dag_round).await;
+                if response.change_epoch {
                     epoch_changed = true;
                 }
             }

--- a/core/consensus/src/execution/worker.rs
+++ b/core/consensus/src/execution/worker.rs
@@ -299,7 +299,7 @@ async fn handle_consensus_output<P: PubSub<PubSubMsg>, Q: SyncQueryRunnerInterfa
         ctx.on_committee = ctx.committee.contains(&ctx.our_index);
 
         if !is_epoch_era_changed {
-            ctx.txn_store.change_committee(&ctx.committee);
+            ctx.txn_store.change_epoch(&ctx.committee);
         }
     }
 }
@@ -547,7 +547,7 @@ async fn execute_digest<P: PubSub<PubSubMsg>, Q: SyncQueryRunnerInterface, NE: E
                     .unwrap_or(u32::MAX);
                 ctx.on_committee = ctx.committee.contains(&ctx.our_index);
                 ctx.reconfigure_notify.notify_waiters();
-                ctx.txn_store.change_committee(&ctx.committee);
+                ctx.txn_store.change_epoch(&ctx.committee);
             }
         },
         Err(not_executed) => {

--- a/core/consensus/src/execution/worker.rs
+++ b/core/consensus/src/execution/worker.rs
@@ -298,7 +298,9 @@ async fn handle_consensus_output<P: PubSub<PubSubMsg>, Q: SyncQueryRunnerInterfa
             .unwrap_or(u32::MAX);
         ctx.on_committee = ctx.committee.contains(&ctx.our_index);
 
-        ctx.txn_store.change_committee(&ctx.committee);
+        if !is_epoch_era_changed {
+            ctx.txn_store.change_committee(&ctx.committee);
+        }
     }
 }
 

--- a/core/consensus/src/tests.rs
+++ b/core/consensus/src/tests.rs
@@ -116,7 +116,7 @@ fn test_ring_buffer_epoch_change() {
     // Since the pending parcel was sent from a committee member (2), it be marked as valid after
     // the epoch change.
     let new_committee = vec![0, 1, 2, 3];
-    ring_buffer.change_epoch(&new_committee);
+    ring_buffer.change_committee(&new_committee);
     assert_eq!(
         ring_buffer.get_parcel(&digest).unwrap().inner.to_digest(),
         digest
@@ -124,7 +124,7 @@ fn test_ring_buffer_epoch_change() {
 
     // We keep track of parcels from the previous epoch, so the parcel should still be available.
     let new_committee = vec![0, 5, 4, 3];
-    ring_buffer.change_epoch(&new_committee);
+    ring_buffer.change_committee(&new_committee);
 
     assert_eq!(
         ring_buffer.get_parcel(&digest).unwrap().inner.to_digest(),
@@ -133,7 +133,7 @@ fn test_ring_buffer_epoch_change() {
 
     // But now it should be garbage collected
     let new_committee = vec![0, 2, 1, 3];
-    ring_buffer.change_epoch(&new_committee);
+    ring_buffer.change_committee(&new_committee);
 
     assert!(ring_buffer.get_parcel(&digest).is_none());
 }
@@ -156,7 +156,7 @@ fn test_ring_buffer_invalid_parcel() {
     // The parcel originator (8) is not on the new committee, so the parcel should be marked as
     // invalid and removed.
     let new_committee = vec![0, 1, 2, 3];
-    ring_buffer.change_epoch(&new_committee);
+    ring_buffer.change_committee(&new_committee);
     assert!(ring_buffer.get_parcel(&digest).is_none());
 }
 

--- a/core/consensus/src/tests.rs
+++ b/core/consensus/src/tests.rs
@@ -116,7 +116,7 @@ fn test_ring_buffer_epoch_change() {
     // Since the pending parcel was sent from a committee member (2), it be marked as valid after
     // the epoch change.
     let new_committee = vec![0, 1, 2, 3];
-    ring_buffer.change_committee(&new_committee);
+    ring_buffer.change_epoch(&new_committee);
     assert_eq!(
         ring_buffer.get_parcel(&digest).unwrap().inner.to_digest(),
         digest
@@ -124,7 +124,7 @@ fn test_ring_buffer_epoch_change() {
 
     // We keep track of parcels from the previous epoch, so the parcel should still be available.
     let new_committee = vec![0, 5, 4, 3];
-    ring_buffer.change_committee(&new_committee);
+    ring_buffer.change_epoch(&new_committee);
 
     assert_eq!(
         ring_buffer.get_parcel(&digest).unwrap().inner.to_digest(),
@@ -133,7 +133,7 @@ fn test_ring_buffer_epoch_change() {
 
     // But now it should be garbage collected
     let new_committee = vec![0, 2, 1, 3];
-    ring_buffer.change_committee(&new_committee);
+    ring_buffer.change_epoch(&new_committee);
 
     assert!(ring_buffer.get_parcel(&digest).is_none());
 }
@@ -156,7 +156,7 @@ fn test_ring_buffer_invalid_parcel() {
     // The parcel originator (8) is not on the new committee, so the parcel should be marked as
     // invalid and removed.
     let new_committee = vec![0, 1, 2, 3];
-    ring_buffer.change_committee(&new_committee);
+    ring_buffer.change_epoch(&new_committee);
     assert!(ring_buffer.get_parcel(&digest).is_none());
 }
 

--- a/core/e2e/src/swarm.rs
+++ b/core/e2e/src/swarm.rs
@@ -397,6 +397,8 @@ impl SwarmBuilder {
             committee_selection_beacon_commit_phase_duration: 10,
             committee_selection_beacon_reveal_phase_duration: 10,
 
+            committee_selection_beacon_non_reveal_slash_amount: 1000,
+
             ..Default::default()
         };
 

--- a/core/forwarder/src/forwarder.rs
+++ b/core/forwarder/src/forwarder.rs
@@ -30,8 +30,9 @@ impl<C: NodeComponents> BuildGraph for Forwarder<C> {
              app: &C::ApplicationInterface,
              fdi::Cloned(waiter): fdi::Cloned<ShutdownWaiter>| {
                 let consensus_key = keystore.get_bls_pk();
+                let node_public_key = keystore.get_ed25519_pk();
                 let query_runner = app.sync_query();
-                let worker = Worker::new(consensus_key, query_runner);
+                let worker = Worker::new(consensus_key, node_public_key, query_runner);
                 let socket = spawn_worker!(worker, "FORWARDER", waiter, crucial);
 
                 Self {

--- a/core/interfaces/src/application.rs
+++ b/core/interfaces/src/application.rs
@@ -168,6 +168,9 @@ pub trait SyncQueryRunnerInterface: Clone + Send + Sync + 'static {
         Option<CommitteeSelectionBeaconReveal>,
     )>;
 
+    /// Get the non-revealing nodes from the previous round.
+    fn get_committee_selection_beacon_non_revealing_nodes(&self) -> Vec<NodeIndex>;
+
     /// Query Services Table
     /// Returns the service information for a given [`ServiceId`]
     fn get_service_info(&self, id: &ServiceId) -> Option<Service>;

--- a/core/interfaces/src/committee_beacon.rs
+++ b/core/interfaces/src/committee_beacon.rs
@@ -1,6 +1,6 @@
 use fdi::BuildGraph;
 use fxhash::FxHashMap;
-use lightning_types::{CommitteeSelectionBeaconCommit, CommitteeSelectionBeaconReveal};
+use lightning_types::{CommitteeSelectionBeaconCommit, CommitteeSelectionBeaconReveal, Epoch};
 
 use crate::components::NodeComponents;
 
@@ -21,5 +21,5 @@ pub trait CommitteeBeaconQueryInterface: Clone + Send + Sync + 'static {
     /// Get all locally stored beacons.
     fn get_beacons(
         &self,
-    ) -> FxHashMap<CommitteeSelectionBeaconCommit, CommitteeSelectionBeaconReveal>;
+    ) -> FxHashMap<(Epoch, CommitteeSelectionBeaconCommit), CommitteeSelectionBeaconReveal>;
 }

--- a/core/interfaces/src/reputation.rs
+++ b/core/interfaces/src/reputation.rs
@@ -1,7 +1,8 @@
+use std::collections::BTreeMap;
 use std::time::Duration;
 
 use fdi::BuildGraph;
-use lightning_types::NodeIndex;
+use lightning_types::{NodeIndex, ReputationMeasurements};
 
 use crate::components::NodeComponents;
 
@@ -31,6 +32,9 @@ pub trait ReputationAggregatorInterface<C: NodeComponents>: BuildGraph {
 pub trait ReputationQueryInteface: Clone + Send + Sync {
     /// Returns the reputation of the provided node locally.
     fn get_reputation_of(&self, peer: &NodeIndex) -> Option<u8>;
+
+    /// Returns reputation measurements for all peers.
+    fn get_measurements(&self) -> BTreeMap<NodeIndex, ReputationMeasurements>;
 }
 
 /// Reputation reporter is a cheaply cleanable object which can be used to report the interactions

--- a/core/rep-collector/src/tests.rs
+++ b/core/rep-collector/src/tests.rs
@@ -313,14 +313,20 @@ async fn test_reputation_calculation_and_query() {
     // Wait until all measurements have been submitted to the application.
     poll_until(
         || async {
-            let alice_rep = app_query
+            let alice_rep_count = app_query
                 .get_reputation_measurements(&alice)
-                .unwrap_or(Vec::new());
-            let bob_rep = app_query
+                .unwrap_or(Vec::new())
+                .iter()
+                .filter(|m| m.measurements.interactions.is_some())
+                .count();
+            let bob_rep_count = app_query
                 .get_reputation_measurements(&bob)
-                .unwrap_or(Vec::new());
+                .unwrap_or(Vec::new())
+                .iter()
+                .filter(|m| m.measurements.interactions.is_some())
+                .count();
 
-            (alice_rep.len() == 2 && bob_rep.len() == 2)
+            (alice_rep_count == 2 && bob_rep_count == 2)
                 .then_some(())
                 .ok_or(PollUntilError::ConditionNotSatisfied)
         },

--- a/core/test-utils/src/e2e/bindings.rs
+++ b/core/test-utils/src/e2e/bindings.rs
@@ -56,6 +56,24 @@ partial_node_components!(TestFullNodeComponentsWithMockConsensus {
     TopologyInterface = Topology<Self>;
 });
 
+partial_node_components!(TestFullNodeComponentsWithRealConsensusWithoutCommitteeBeacon {
+    ApplicationInterface = Application<Self>;
+    BroadcastInterface = SyncBroadcaster<Self>;
+    BlockstoreInterface = Blockstore<Self>;
+    CheckpointerInterface = Checkpointer<Self>;
+    ConfigProviderInterface = TomlConfigProvider<Self>;
+    ConsensusInterface = Consensus<Self>;
+    ForwarderInterface = Forwarder<Self>;
+    KeystoreInterface = EphemeralKeystore<Self>;
+    NotifierInterface = Notifier<Self>;
+    PingerInterface = Pinger<Self>;
+    PoolInterface = PoolProvider<Self>;
+    ReputationAggregatorInterface = ReputationAggregator<Self>;
+    RpcInterface = Rpc<Self>;
+    SignerInterface = Signer<Self>;
+    TopologyInterface = Topology<Self>;
+});
+
 partial_node_components!(TestFullNodeComponentsWithoutCommitteeBeacon {
     ApplicationInterface = Application<Self>;
     BroadcastInterface = SyncBroadcaster<Self>;

--- a/core/test-utils/src/e2e/genesis.rs
+++ b/core/test-utils/src/e2e/genesis.rs
@@ -147,6 +147,7 @@ impl TestGenesisBuilder {
             topology_min_nodes: 16,
             committee_selection_beacon_commit_phase_duration: 10,
             committee_selection_beacon_reveal_phase_duration: 10,
+            committee_selection_beacon_non_reveal_slash_amount: 1000,
         };
 
         if let Some(mutator) = self.mutator {

--- a/core/test-utils/src/e2e/network_app.rs
+++ b/core/test-utils/src/e2e/network_app.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::time::Duration;
 
 use anyhow::Result;
@@ -80,10 +81,8 @@ impl TestNetwork {
     /// This method uses the first node in the network to get the current epoch and committee.
     pub fn committee_nodes(&self) -> Vec<&BoxedTestNode> {
         let node = self.node(0);
-        let epoch = node.app_query().get_current_epoch();
         node.app_query()
-            .get_committee_info(&epoch, |committee| committee.members)
-            .unwrap_or_default()
+            .get_committee_members_by_index()
             .into_iter()
             .map(|index| self.node(index))
             .collect()
@@ -94,11 +93,11 @@ impl TestNetwork {
     /// This method uses the first node in the network to get the current epoch and committee.
     pub fn non_committee_nodes(&self) -> Vec<&BoxedTestNode> {
         let node = self.node(0);
-        let epoch = node.app_query().get_current_epoch();
         let committee_nodes = node
             .app_query()
-            .get_committee_info(&epoch, |committee| committee.members)
-            .unwrap_or_default();
+            .get_committee_members_by_index()
+            .into_iter()
+            .collect::<HashSet<_>>();
         self.nodes()
             .filter(|node| !committee_nodes.contains(&node.index()))
             .collect()

--- a/core/test-utils/src/e2e/node.rs
+++ b/core/test-utils/src/e2e/node.rs
@@ -140,7 +140,11 @@ impl<C: NodeComponents> TestNetworkNode for TestFullNode<C> {
     }
 
     async fn shutdown(self: Box<Self>) {
-        self.inner.shutdown().await;
+        tokio::time::timeout(Duration::from_secs(30), async move {
+            self.inner.shutdown().await;
+        })
+        .await
+        .unwrap();
     }
 
     async fn get_node_ports(&self) -> Result<NodePorts> {

--- a/core/types/src/application.rs
+++ b/core/types/src/application.rs
@@ -7,7 +7,7 @@ use fleek_crypto::{EthAddress, NodePublicKey};
 use hp_fixed::unsigned::HpUfixed;
 use serde::{Deserialize, Serialize};
 
-use crate::{BlockNumber, TransactionReceipt};
+use crate::{BlockNumber, Staking, TransactionReceipt};
 
 /// Max number of updates allowed in a content registry update transaction.
 pub const MAX_UPDATES_CONTENT_REGISTRY: usize = 100;
@@ -175,6 +175,15 @@ pub type BlockNodeRegistryChanges = Vec<(NodePublicKey, NodeRegistryChange)>;
 pub enum NodeRegistryChange {
     New,
     Removed,
+    Slashed((HpUfixed<18>, Staking, NodeRegistryChangeSlashReason)),
+}
+
+#[rustfmt::skip]
+#[derive(
+    Debug, PartialEq, PartialOrd, Hash, Eq, Ord, Serialize, Deserialize, Clone, schemars::JsonSchema,
+)]
+pub enum NodeRegistryChangeSlashReason {
+    CommitteeBeaconNonReveal,
 }
 
 /// The account info stored per account on the blockchain

--- a/core/types/src/genesis.rs
+++ b/core/types/src/genesis.rs
@@ -62,6 +62,7 @@ pub struct Genesis {
     pub topology_min_nodes: usize,
     pub committee_selection_beacon_commit_phase_duration: u64,
     pub committee_selection_beacon_reveal_phase_duration: u64,
+    pub committee_selection_beacon_non_reveal_slash_amount: u64,
 }
 
 impl Genesis {

--- a/core/types/src/response.rs
+++ b/core/types/src/response.rs
@@ -3,7 +3,7 @@ use fleek_crypto::{EthAddress, TransactionSender};
 use serde::{Deserialize, Serialize};
 
 use super::{Epoch, NodeInfo};
-use crate::{Event, UpdateMethod};
+use crate::{EpochEra, Event, UpdateMethod};
 
 /// Info on a Narwhal epoch
 #[derive(
@@ -14,6 +14,8 @@ pub struct EpochInfo {
     pub committee: Vec<NodeInfo>,
     /// The current epoch number
     pub epoch: Epoch,
+    /// The current epoch era
+    pub epoch_era: EpochEra,
     /// Timestamp when the epoch ends
     pub epoch_end: u64,
 }

--- a/core/types/src/state.rs
+++ b/core/types/src/state.rs
@@ -22,6 +22,9 @@ pub type ServiceId = u32;
 /// Application epoch number
 pub type Epoch = u64;
 
+/// Application epoch era.
+pub type EpochEra = u64;
+
 /// A nodes index
 pub type NodeIndex = u32;
 
@@ -103,6 +106,7 @@ pub enum Metadata {
     SubDagRound,
     CommitteeSelectionBeaconPhase,
     CommitteeSelectionBeaconRound,
+    EpochEra,
 }
 
 /// The Value enum is a data type used to represent values in a key-value pair for a metadata table
@@ -122,6 +126,7 @@ pub enum Value {
     BlockRange(u64, u64),
     CommitteeSelectionBeaconPhase(CommitteeSelectionBeaconPhase),
     CommitteeSelectionBeaconRound(CommitteeSelectionBeaconRound),
+    EpochEra(u64),
 }
 
 impl Value {

--- a/core/types/src/state.rs
+++ b/core/types/src/state.rs
@@ -272,6 +272,8 @@ pub enum ProtocolParamKey {
     CommitteeSelectionBeaconCommitPhaseDuration = 18,
     /// The committee selection beacon reveal phase duration in blocks
     CommitteeSelectionBeaconRevealPhaseDuration = 19,
+    /// The slash amount for non-revealing nodes in the committee selection beacon process.
+    CommitteeSelectionBeaconNonRevealSlashAmount = 20,
 }
 
 /// The Value enum is a data type used to represent values in a key-value pair for a metadata table
@@ -297,6 +299,7 @@ pub enum ProtocolParamValue {
     TopologyMinNodes(usize),
     CommitteeSelectionBeaconCommitPhaseDuration(u64),
     CommitteeSelectionBeaconRevealPhaseDuration(u64),
+    CommitteeSelectionBeaconNonRevealSlashAmount(u64),
 }
 
 impl ProtocolParamValue {
@@ -326,6 +329,9 @@ impl ProtocolParamValue {
                 Cow::Owned(i.to_le_bytes().to_vec())
             },
             ProtocolParamValue::CommitteeSelectionBeaconRevealPhaseDuration(i) => {
+                Cow::Owned(i.to_le_bytes().to_vec())
+            },
+            ProtocolParamValue::CommitteeSelectionBeaconNonRevealSlashAmount(i) => {
                 Cow::Owned(i.to_le_bytes().to_vec())
             },
         }

--- a/core/utils/src/application.rs
+++ b/core/utils/src/application.rs
@@ -16,7 +16,7 @@ use lightning_interfaces::types::{
     Value,
 };
 use lightning_interfaces::PagingParams;
-use types::{CommitteeSelectionBeaconPhase, Participation};
+use types::{CommitteeSelectionBeaconPhase, EpochEra, Participation};
 
 pub trait QueryRunnerExt: SyncQueryRunnerInterface {
     /// Returns the chain id
@@ -51,10 +51,19 @@ pub trait QueryRunnerExt: SyncQueryRunnerInterface {
         }
     }
 
+    /// Get current epoch era.
+    fn get_epoch_era(&self) -> EpochEra {
+        match self.get_metadata(&Metadata::EpochEra) {
+            Some(Value::EpochEra(era)) => era,
+            _ => 0,
+        }
+    }
+
     /// Get Current Epoch Info
     /// Returns all the information on the current epoch that Narwhal needs to run
     fn get_epoch_info(&self) -> EpochInfo {
         let epoch = self.get_current_epoch();
+        let epoch_era = self.get_epoch_era();
         // look up current committee
         let committee = self.get_committee_info(&epoch, |c| c).unwrap_or_default();
         EpochInfo {
@@ -64,6 +73,7 @@ pub trait QueryRunnerExt: SyncQueryRunnerInterface {
                 .filter_map(|member| self.get_node_info::<NodeInfo>(member, |n| n))
                 .collect(),
             epoch,
+            epoch_era,
             epoch_end: committee.epoch_end_timestamp,
         }
     }


### PR DESCRIPTION
Slash nodes that commit without revealing in the committee selection random beacon process.
- `NodeRegistryChange::Slashed` is used to propagate the slashing event on the block execution response. 
- `Metadata::EpochEra` is introduced to reset the narwhal store/dag so that it can be reconfigured mid-epoch when a committee member is slashed and no longer has sufficient stake.