### PR TITLE
chore(pool): fix endless loop during shutdown

### DIFF
--- a/core/pool/src/event.rs
+++ b/core/pool/src/event.rs
@@ -418,7 +418,10 @@ where
                     task.abort();
                 }
                 self.ongoing_async_tasks.clear();
-                while !matches!(self.event_queue.try_recv(), Err(TryRecvError::Empty)) {}
+                while !matches!(
+                    self.event_queue.try_recv(),
+                    Err(TryRecvError::Empty | TryRecvError::Disconnected)
+                ) {}
             },
             "POOL: spawn"
         );


### PR DESCRIPTION
During node shutdown, the pool will sometimes hang and keep the whole thing from shutting down. It doesn't happen often, but when it does it's been tough to track down. It seems to be slightly more reproducable by making a test panic that has a few nodes running with activity between them and looping that until it happens, and so that's what I did and was able to finally track it down using the tokio console, seeing that the pool task was still running, and narrowing it down from there. It's been getting caught up in this loop that attempts to drain the event queue before shutting down:
```rust
while !matches!(self.event_queue.try_recv(), Err(TryRecvError::Empty)) {}
```

But `try_recv` will sometimes return `Err(TryRecvError::Disconnected)` at this point. So this PR updates the loop condition to include that error too.