### PR TITLE
chore: change rpc port

### DIFF
--- a/core/rpc/src/config.rs
+++ b/core/rpc/src/config.rs
@@ -60,10 +60,10 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             hmac_secret_dir: None,
-            addr: "0.0.0.0:4230".parse().expect("RPC Socket Addr to parse"),
+            addr: "0.0.0.0:4240".parse().expect("RPC Socket Addr to parse"),
             rpc_selection: Default::default(),
             disallowed_methods: None,
-            firewall: FirewallConfig::none("rpc-4230".to_string()),
+            firewall: FirewallConfig::none("rpc-4240".to_string()),
         }
     }
 }

--- a/core/types/src/state.rs
+++ b/core/types/src/state.rs
@@ -410,7 +410,7 @@ impl Default for NodePorts {
             worker: 4311,
             mempool: 4210,
             handshake: Default::default(),
-            rpc: 4230,
+            rpc: 4240,
             pinger: 4350,
         }
     }


### PR DESCRIPTION
Change the rpc port to 4240 to make it consistent with the docs and current testnet