### PR TITLE
feat(application): implement withdraws

### DIFF
--- a/core/application/src/env.rs
+++ b/core/application/src/env.rs
@@ -242,6 +242,8 @@ impl ApplicationEnv {
 
             metadata_table.insert(Metadata::BlockNumber, Value::BlockNumber(0));
 
+            metadata_table.insert(Metadata::WithdrawId, Value::WithdrawId(0));
+
             metadata_table.insert(
                 Metadata::ProtocolFundAddress,
                 Value::AccountPublicKey(genesis.protocol_fund_address),

--- a/core/application/src/state/executor/epoch_change.rs
+++ b/core/application/src/state/executor/epoch_change.rs
@@ -676,6 +676,12 @@ impl<B: Backend> StateExecutor<B> {
         // Clear executed digests.
         self.executed_digests.clear();
 
+        // Clear withdraws
+        self.flk_withdraws.clear();
+        self.usdc_withdraws.clear();
+        self.metadata
+            .set(Metadata::WithdrawId, Value::WithdrawId(0));
+
         self.committee_info.set(epoch, current_committee);
         // Get new committee
         let new_committee = self.choose_new_committee(beacons);

--- a/core/application/src/state/query.rs
+++ b/core/application/src/state/query.rs
@@ -79,6 +79,8 @@ pub struct QueryRunner {
         ),
     >,
     committee_selection_beacon_non_revealing_node: ResolvedTableReference<NodeIndex, ()>,
+    flk_withdraws: ResolvedTableReference<u64, (EthAddress, HpUfixed<18>)>,
+    usdc_withdraws: ResolvedTableReference<u64, (EthAddress, HpUfixed<6>)>,
 }
 
 impl QueryRunner {
@@ -122,7 +124,8 @@ impl SyncQueryRunnerInterface for QueryRunner {
             )>("committee_selection_beacon"),
             committee_selection_beacon_non_revealing_node: atomo
                 .resolve::<NodeIndex, ()>("committee_selection_beacon_non_revealing_node"),
-
+            flk_withdraws: atomo.resolve::<u64, (EthAddress, HpUfixed<18>)>("flk_withdraws"),
+            usdc_withdraws: atomo.resolve::<u64, (EthAddress, HpUfixed<6>)>("usdc_withdraws"),
             inner: atomo,
         }
     }
@@ -371,5 +374,21 @@ impl SyncQueryRunnerInterface for QueryRunner {
     fn has_genesis(&self) -> bool {
         // This is consistent with the logic in `Env::apply_genesis_block`.
         self.get_metadata(&Metadata::Epoch).is_some()
+    }
+
+    fn get_flk_withdraws(&self) -> Vec<(u64, EthAddress, HpUfixed<18>)> {
+        self.inner
+            .run(|ctx| self.flk_withdraws.get(ctx).as_map())
+            .iter()
+            .map(|(id, (address, amount))| (*id, *address, amount.clone()))
+            .collect()
+    }
+
+    fn get_usdc_withdraws(&self) -> Vec<(u64, EthAddress, HpUfixed<6>)> {
+        self.inner
+            .run(|ctx| self.usdc_withdraws.get(ctx).as_map())
+            .iter()
+            .map(|(id, (address, amount))| (*id, *address, amount.clone()))
+            .collect()
     }
 }

--- a/core/application/src/state/writer.rs
+++ b/core/application/src/state/writer.rs
@@ -188,6 +188,8 @@ impl ApplicationState<AtomoStorage, DefaultSerdeBackend, ApplicationStateTree> {
                 Option<CommitteeSelectionBeaconReveal>,
             )>("committee_selection_beacon")
             .with_table::<NodeIndex, ()>("committee_selection_beacon_non_revealing_node")
+            .with_table::<u64, (EthAddress, HpUfixed<18>)>("flk_withdraws")
+            .with_table::<u64, (EthAddress, HpUfixed<6>)>("usdc_withdraws")
             .enable_iter("current_epoch_served")
             .enable_iter("rep_measurements")
             .enable_iter("submitted_rep_measurements")
@@ -200,7 +202,9 @@ impl ApplicationState<AtomoStorage, DefaultSerdeBackend, ApplicationStateTree> {
             .enable_iter("uri_to_node")
             .enable_iter("node_to_uri")
             .enable_iter("committee_selection_beacon")
-            .enable_iter("committee_selection_beacon_non_revealing_node");
+            .enable_iter("committee_selection_beacon_non_revealing_node")
+            .enable_iter("flk_withdraws")
+            .enable_iter("usdc_withdraws");
 
         #[cfg(debug_assertions)]
         {

--- a/core/interfaces/src/application.rs
+++ b/core/interfaces/src/application.rs
@@ -8,6 +8,7 @@ use atomo::{Atomo, InMemoryStorage, KeyIterator, QueryPerm, StorageBackend};
 use fdi::BuildGraph;
 use fleek_crypto::{ClientPublicKey, EthAddress, NodePublicKey};
 use fxhash::FxHashMap;
+use hp_fixed::unsigned::HpUfixed;
 use lightning_types::{
     AccountInfo,
     Blake3Hash,
@@ -240,6 +241,12 @@ pub trait SyncQueryRunnerInterface: Clone + Send + Sync + 'static {
 
     // Returns whether the genesis block has been applied.
     fn has_genesis(&self) -> bool;
+
+    /// Returns a list of FLK withdraws
+    fn get_flk_withdraws(&self) -> Vec<(u64, EthAddress, HpUfixed<18>)>;
+
+    /// Returns a list of USDC withdraws
+    fn get_usdc_withdraws(&self) -> Vec<(u64, EthAddress, HpUfixed<6>)>;
 }
 
 #[derive(Clone, Debug)]

--- a/core/types/src/response.rs
+++ b/core/types/src/response.rs
@@ -144,6 +144,7 @@ pub enum ExecutionError {
     NotNodeOwner,
     NotCommitteeMember,
     NodeDoesNotExist,
+    AccountDoesNotExist,
     CantSendToYourself,
     AlreadySignaled,
     SubmittedTooManyTransactions,

--- a/core/types/src/state.rs
+++ b/core/types/src/state.rs
@@ -107,6 +107,7 @@ pub enum Metadata {
     CommitteeSelectionBeaconPhase,
     CommitteeSelectionBeaconRound,
     EpochEra,
+    WithdrawId,
 }
 
 /// The Value enum is a data type used to represent values in a key-value pair for a metadata table
@@ -127,6 +128,7 @@ pub enum Value {
     CommitteeSelectionBeaconPhase(CommitteeSelectionBeaconPhase),
     CommitteeSelectionBeaconRound(CommitteeSelectionBeaconRound),
     EpochEra(u64),
+    WithdrawId(u64),
 }
 
 impl Value {


### PR DESCRIPTION
Implements the withdraw transaction. This also adds state tables that keep track of withdraws for the epoch. The tables are cleared after the epoch ends. This will allow the bridge to query the state for pending withdraws. 