### PR TITLE
chore(origin-ipfs): update gateways in config

### DIFF
--- a/core/origin-ipfs/src/config.rs
+++ b/core/origin-ipfs/src/config.rs
@@ -40,17 +40,17 @@ impl Default for Config {
                 },
                 Gateway {
                     protocol: Protocol::Https,
+                    authority: "cf-ipfs.com".to_string(),
+                    request_format: RequestFormat::CidLast,
+                },
+                Gateway {
+                    protocol: Protocol::Https,
                     authority: "fleek.ipfs.io".to_string(),
                     request_format: RequestFormat::CidLast,
                 },
                 Gateway {
                     protocol: Protocol::Https,
                     authority: "ipfs.io".to_string(),
-                    request_format: RequestFormat::CidLast,
-                },
-                Gateway {
-                    protocol: Protocol::Https,
-                    authority: "ipfs.runfission.com".to_string(),
                     request_format: RequestFormat::CidLast,
                 },
             ],


### PR DESCRIPTION
Update the gateways in the origin-ipfs config to match the gateways used on the current testnet.