### PR TITLE
feat(rpc): add endpoints to query withdraw state table

### DIFF
--- a/core/application/src/state/query.rs
+++ b/core/application/src/state/query.rs
@@ -41,7 +41,7 @@ use lightning_interfaces::types::{
     TxHash,
     Value,
 };
-use lightning_interfaces::SyncQueryRunnerInterface;
+use lightning_interfaces::{SyncQueryRunnerInterface, WithdrawPagingParams};
 use merklize::{StateRootHash, StateTree};
 
 use crate::env::ApplicationStateTree;
@@ -376,19 +376,29 @@ impl SyncQueryRunnerInterface for QueryRunner {
         self.get_metadata(&Metadata::Epoch).is_some()
     }
 
-    fn get_flk_withdraws(&self) -> Vec<(u64, EthAddress, HpUfixed<18>)> {
+    fn get_flk_withdraws(
+        &self,
+        paging: WithdrawPagingParams,
+    ) -> Vec<(u64, EthAddress, HpUfixed<18>)> {
         self.inner
             .run(|ctx| self.flk_withdraws.get(ctx).as_map())
             .iter()
             .map(|(id, (address, amount))| (*id, *address, amount.clone()))
+            .filter(|(id, _, _)| id >= &paging.start)
+            .take(paging.limit)
             .collect()
     }
 
-    fn get_usdc_withdraws(&self) -> Vec<(u64, EthAddress, HpUfixed<6>)> {
+    fn get_usdc_withdraws(
+        &self,
+        paging: WithdrawPagingParams,
+    ) -> Vec<(u64, EthAddress, HpUfixed<6>)> {
         self.inner
             .run(|ctx| self.usdc_withdraws.get(ctx).as_map())
             .iter()
             .map(|(id, (address, amount))| (*id, *address, amount.clone()))
+            .filter(|(id, _, _)| id >= &paging.start)
+            .take(paging.limit)
             .collect()
     }
 }

--- a/core/application/src/tests/balances.rs
+++ b/core/application/src/tests/balances.rs
@@ -8,7 +8,7 @@ use lightning_interfaces::types::{
     Tokens,
     UpdateMethod,
 };
-use lightning_interfaces::SyncQueryRunnerInterface;
+use lightning_interfaces::{SyncQueryRunnerInterface, WithdrawPagingParams};
 use tempfile::tempdir;
 
 use super::utils::*;
@@ -255,7 +255,10 @@ async fn test_withdraw_usdc_works_properly() {
     let update = prepare_update_request_account(withdraw, &owner_secret_key, 1);
     expect_tx_success(update, &update_socket, ExecutionData::None).await;
 
-    let withdraws = query_runner.get_usdc_withdraws();
+    let withdraws = query_runner.get_usdc_withdraws(WithdrawPagingParams {
+        start: 0,
+        limit: 100,
+    });
     assert_eq!(withdraws[0].1, receiver);
     assert_eq!(withdraws[0].2, withdraw_amount.into());
 }
@@ -291,7 +294,10 @@ async fn test_withdraw_flk_works_properly() {
     let update = prepare_update_request_account(withdraw, &owner_secret_key, 1);
     expect_tx_success(update, &update_socket, ExecutionData::None).await;
 
-    let withdraws = query_runner.get_flk_withdraws();
+    let withdraws = query_runner.get_flk_withdraws(WithdrawPagingParams {
+        start: 0,
+        limit: 100,
+    });
     assert_eq!(withdraws[0].1, receiver);
     assert_eq!(withdraws[0].2, withdraw_amount.into());
 }

--- a/core/application/src/tests/utils.rs
+++ b/core/application/src/tests/utils.rs
@@ -31,7 +31,7 @@ use lightning_interfaces::types::{
     ReputationMeasurements,
     Staking,
 };
-use lightning_interfaces::PagingParams;
+use lightning_interfaces::NodePagingParams;
 use lightning_node::Node;
 use lightning_test_utils::e2e::{try_init_tracing, TestGenesisBuilder, TestGenesisNodeBuilder};
 use lightning_test_utils::json_config::JsonConfigProvider;
@@ -857,8 +857,8 @@ pub(crate) fn update_reputation_measurements(
 }
 
 /// Helper function that prepare `PagingParams`
-pub(crate) fn paging_params(ignore_stake: bool, start: u32, limit: usize) -> PagingParams {
-    PagingParams {
+pub(crate) fn paging_params(ignore_stake: bool, start: u32, limit: usize) -> NodePagingParams {
+    NodePagingParams {
         ignore_stake,
         start,
         limit,

--- a/core/interfaces/src/application.rs
+++ b/core/interfaces/src/application.rs
@@ -243,10 +243,16 @@ pub trait SyncQueryRunnerInterface: Clone + Send + Sync + 'static {
     fn has_genesis(&self) -> bool;
 
     /// Returns a list of FLK withdraws
-    fn get_flk_withdraws(&self) -> Vec<(u64, EthAddress, HpUfixed<18>)>;
+    fn get_flk_withdraws(
+        &self,
+        paging: WithdrawPagingParams,
+    ) -> Vec<(u64, EthAddress, HpUfixed<18>)>;
 
     /// Returns a list of USDC withdraws
-    fn get_usdc_withdraws(&self) -> Vec<(u64, EthAddress, HpUfixed<6>)>;
+    fn get_usdc_withdraws(
+        &self,
+        paging: WithdrawPagingParams,
+    ) -> Vec<(u64, EthAddress, HpUfixed<6>)>;
 }
 
 #[derive(Clone, Debug)]
@@ -262,7 +268,7 @@ pub enum ExecutionError {
 }
 
 #[derive(Deserialize, Serialize, schemars::JsonSchema)]
-pub struct PagingParams {
+pub struct NodePagingParams {
     // Since some nodes may be in state without
     // having staked the minimum and if at any point
     // they stake the minimum amount, this would
@@ -271,5 +277,11 @@ pub struct PagingParams {
     // to keep returned results consistent.
     pub ignore_stake: bool,
     pub start: NodeIndex,
+    pub limit: usize,
+}
+
+#[derive(Deserialize, Serialize, schemars::JsonSchema)]
+pub struct WithdrawPagingParams {
+    pub start: u64,
     pub limit: usize,
 }

--- a/core/rpc/src/api/flk.rs
+++ b/core/rpc/src/api/flk.rs
@@ -22,7 +22,7 @@ use lightning_interfaces::types::{
     TotalServed,
     TransactionRequest,
 };
-use lightning_interfaces::PagingParams;
+use lightning_interfaces::{NodePagingParams, WithdrawPagingParams};
 use lightning_openrpc_macros::open_rpc;
 use lightning_types::{ProtocolParamKey, StateProofKey, StateProofValue};
 use merklize::{StateRootHash, StateTree};
@@ -154,12 +154,13 @@ pub trait FleekApi {
     async fn node_has_sufficient_stake(&self, public_key: NodePublicKey) -> RpcResult<bool>;
 
     #[method(name = "get_node_registry")]
-    async fn get_node_registry(&self, paging: Option<PagingParams>) -> RpcResult<Vec<NodeInfo>>;
+    async fn get_node_registry(&self, paging: Option<NodePagingParams>)
+    -> RpcResult<Vec<NodeInfo>>;
 
     #[method(name = "get_node_registry_index")]
     async fn get_node_registry_index(
         &self,
-        paging: Option<PagingParams>,
+        paging: Option<NodePagingParams>,
     ) -> RpcResult<Vec<NodeInfoWithIndex>>;
 
     #[method(name = "get_reputation")]
@@ -218,6 +219,20 @@ pub trait FleekApi {
 
     #[method(name = "metrics")]
     async fn metrics(&self) -> RpcResult<String>;
+
+    #[method(name = "get_flk_withdraws")]
+    async fn get_flk_withdraws(
+        &self,
+        epoch: Option<u64>,
+        paging: WithdrawPagingParams,
+    ) -> RpcResult<Vec<(u64, EthAddress, HpUfixed<18>)>>;
+
+    #[method(name = "get_usdc_withdraws")]
+    async fn get_usdc_withdraws(
+        &self,
+        epoch: Option<u64>,
+        paging: WithdrawPagingParams,
+    ) -> RpcResult<Vec<(u64, EthAddress, HpUfixed<6>)>>;
 
     #[subscription(name = "subscribe", item = Event)]
     async fn handle_subscription(&self, event_type: Option<EventType>) -> SubscriptionResult;

--- a/core/rpc/src/logic/flk_impl.rs
+++ b/core/rpc/src/logic/flk_impl.rs
@@ -28,7 +28,7 @@ use lightning_interfaces::types::{
     TransactionRequest,
     Value,
 };
-use lightning_interfaces::PagingParams;
+use lightning_interfaces::{NodePagingParams, WithdrawPagingParams};
 use lightning_types::{AggregateCheckpoint, StateProofKey, StateProofValue};
 use lightning_utils::application::QueryRunnerExt;
 use merklize::{StateRootHash, StateTree};
@@ -302,7 +302,10 @@ impl<C: NodeComponents> FleekApiServer for FleekApi<C> {
         Ok(self.data.query_runner.has_sufficient_stake(&pk))
     }
 
-    async fn get_node_registry(&self, paging: Option<PagingParams>) -> RpcResult<Vec<NodeInfo>> {
+    async fn get_node_registry(
+        &self,
+        paging: Option<NodePagingParams>,
+    ) -> RpcResult<Vec<NodeInfo>> {
         Ok(self
             .data
             .query_runner
@@ -314,7 +317,7 @@ impl<C: NodeComponents> FleekApiServer for FleekApi<C> {
 
     async fn get_node_registry_index(
         &self,
-        paging: Option<PagingParams>,
+        paging: Option<NodePagingParams>,
     ) -> RpcResult<Vec<NodeInfoWithIndex>> {
         Ok(self.data.query_runner.get_node_registry(paging))
     }
@@ -463,6 +466,30 @@ impl<C: NodeComponents> FleekApiServer for FleekApi<C> {
             Ok(metrics) => Ok(metrics),
             Err(err) => Err(RPCError::custom(err.to_string()).into()),
         }
+    }
+
+    async fn get_flk_withdraws(
+        &self,
+        epoch: Option<u64>,
+        paging: WithdrawPagingParams,
+    ) -> RpcResult<Vec<(u64, EthAddress, HpUfixed<18>)>> {
+        Ok(self
+            .data
+            .query_runner(epoch)
+            .await?
+            .get_flk_withdraws(paging))
+    }
+
+    async fn get_usdc_withdraws(
+        &self,
+        epoch: Option<u64>,
+        paging: WithdrawPagingParams,
+    ) -> RpcResult<Vec<(u64, EthAddress, HpUfixed<6>)>> {
+        Ok(self
+            .data
+            .query_runner(epoch)
+            .await?
+            .get_usdc_withdraws(paging))
     }
 
     async fn handle_subscription(

--- a/core/utils/src/application.rs
+++ b/core/utils/src/application.rs
@@ -15,7 +15,7 @@ use lightning_interfaces::types::{
     ProtocolParamValue,
     Value,
 };
-use lightning_interfaces::PagingParams;
+use lightning_interfaces::NodePagingParams;
 use types::{CommitteeSelectionBeaconPhase, EpochEra, Participation};
 
 pub trait QueryRunnerExt: SyncQueryRunnerInterface {
@@ -156,7 +156,7 @@ pub trait QueryRunnerExt: SyncQueryRunnerInterface {
     /// Returns a full copy of the entire node-registry,
     /// Paging Params - filtering nodes that are still a valid node and have enough stake; Takes
     /// from starting index and specified amount.
-    fn get_node_registry(&self, paging: Option<PagingParams>) -> Vec<NodeInfoWithIndex> {
+    fn get_node_registry(&self, paging: Option<NodePagingParams>) -> Vec<NodeInfoWithIndex> {
         let staking_amount = self.get_staking_amount().into();
 
         self.get_node_table_iter::<Vec<NodeInfoWithIndex>>(|nodes| -> Vec<NodeInfoWithIndex> {
@@ -168,7 +168,7 @@ pub trait QueryRunnerExt: SyncQueryRunnerInterface {
                 None => nodes
                     .filter(|node| node.info.stake.staked >= staking_amount)
                     .collect(),
-                Some(PagingParams {
+                Some(NodePagingParams {
                     ignore_stake,
                     limit,
                     start,


### PR DESCRIPTION
This PR adds endpoints to the RPC server that can be used to query the withdraw state tables that were added in #74.