### PR TITLE
chore: simplify withdraw state tables

### DIFF
--- a/core/application/src/state/executor/epoch_change.rs
+++ b/core/application/src/state/executor/epoch_change.rs
@@ -677,8 +677,7 @@ impl<B: Backend> StateExecutor<B> {
         self.executed_digests.clear();
 
         // Clear withdraws
-        self.flk_withdraws.clear();
-        self.usdc_withdraws.clear();
+        self.withdraws.clear();
         self.metadata
             .set(Metadata::WithdrawId, Value::WithdrawId(0));
 

--- a/core/application/src/state/writer.rs
+++ b/core/application/src/state/writer.rs
@@ -36,6 +36,7 @@ use lightning_interfaces::types::{
     TotalServed,
     TxHash,
     Value,
+    WithdrawInfo,
 };
 use lightning_interfaces::SyncQueryRunnerInterface;
 use merklize::StateTree;
@@ -188,8 +189,7 @@ impl ApplicationState<AtomoStorage, DefaultSerdeBackend, ApplicationStateTree> {
                 Option<CommitteeSelectionBeaconReveal>,
             )>("committee_selection_beacon")
             .with_table::<NodeIndex, ()>("committee_selection_beacon_non_revealing_node")
-            .with_table::<u64, (EthAddress, HpUfixed<18>)>("flk_withdraws")
-            .with_table::<u64, (EthAddress, HpUfixed<6>)>("usdc_withdraws")
+            .with_table::<u64, WithdrawInfo>("withdraws")
             .enable_iter("current_epoch_served")
             .enable_iter("rep_measurements")
             .enable_iter("submitted_rep_measurements")
@@ -203,8 +203,7 @@ impl ApplicationState<AtomoStorage, DefaultSerdeBackend, ApplicationStateTree> {
             .enable_iter("node_to_uri")
             .enable_iter("committee_selection_beacon")
             .enable_iter("committee_selection_beacon_non_revealing_node")
-            .enable_iter("flk_withdraws")
-            .enable_iter("usdc_withdraws");
+            .enable_iter("withdraws");
 
         #[cfg(debug_assertions)]
         {

--- a/core/application/src/tests/balances.rs
+++ b/core/application/src/tests/balances.rs
@@ -255,12 +255,12 @@ async fn test_withdraw_usdc_works_properly() {
     let update = prepare_update_request_account(withdraw, &owner_secret_key, 1);
     expect_tx_success(update, &update_socket, ExecutionData::None).await;
 
-    let withdraws = query_runner.get_usdc_withdraws(WithdrawPagingParams {
+    let withdraws = query_runner.get_withdraws(WithdrawPagingParams {
         start: 0,
         limit: 100,
     });
-    assert_eq!(withdraws[0].1, receiver);
-    assert_eq!(withdraws[0].2, withdraw_amount.into());
+    assert_eq!(withdraws[0].info.receiver, receiver);
+    assert_eq!(withdraws[0].info.amount, withdraw_amount.into());
 }
 
 #[tokio::test]
@@ -294,10 +294,10 @@ async fn test_withdraw_flk_works_properly() {
     let update = prepare_update_request_account(withdraw, &owner_secret_key, 1);
     expect_tx_success(update, &update_socket, ExecutionData::None).await;
 
-    let withdraws = query_runner.get_flk_withdraws(WithdrawPagingParams {
+    let withdraws = query_runner.get_withdraws(WithdrawPagingParams {
         start: 0,
         limit: 100,
     });
-    assert_eq!(withdraws[0].1, receiver);
-    assert_eq!(withdraws[0].2, withdraw_amount.into());
+    assert_eq!(withdraws[0].info.receiver, receiver);
+    assert_eq!(withdraws[0].info.amount, withdraw_amount.into());
 }

--- a/core/interfaces/src/application.rs
+++ b/core/interfaces/src/application.rs
@@ -8,7 +8,6 @@ use atomo::{Atomo, InMemoryStorage, KeyIterator, QueryPerm, StorageBackend};
 use fdi::BuildGraph;
 use fleek_crypto::{ClientPublicKey, EthAddress, NodePublicKey};
 use fxhash::FxHashMap;
-use hp_fixed::unsigned::HpUfixed;
 use lightning_types::{
     AccountInfo,
     Blake3Hash,
@@ -25,6 +24,7 @@ use lightning_types::{
     TransactionRequest,
     TxHash,
     Value,
+    WithdrawInfoWithId,
 };
 use merklize::trees::mpt::MptStateProof;
 use merklize::StateRootHash;
@@ -242,17 +242,8 @@ pub trait SyncQueryRunnerInterface: Clone + Send + Sync + 'static {
     // Returns whether the genesis block has been applied.
     fn has_genesis(&self) -> bool;
 
-    /// Returns a list of FLK withdraws
-    fn get_flk_withdraws(
-        &self,
-        paging: WithdrawPagingParams,
-    ) -> Vec<(u64, EthAddress, HpUfixed<18>)>;
-
-    /// Returns a list of USDC withdraws
-    fn get_usdc_withdraws(
-        &self,
-        paging: WithdrawPagingParams,
-    ) -> Vec<(u64, EthAddress, HpUfixed<6>)>;
+    /// Returns a list of withdraws
+    fn get_withdraws(&self, paging: WithdrawPagingParams) -> Vec<WithdrawInfoWithId>;
 }
 
 #[derive(Clone, Debug)]

--- a/core/rpc/src/api/flk.rs
+++ b/core/rpc/src/api/flk.rs
@@ -24,7 +24,7 @@ use lightning_interfaces::types::{
 };
 use lightning_interfaces::{NodePagingParams, WithdrawPagingParams};
 use lightning_openrpc_macros::open_rpc;
-use lightning_types::{ProtocolParamKey, StateProofKey, StateProofValue};
+use lightning_types::{ProtocolParamKey, StateProofKey, StateProofValue, WithdrawInfoWithId};
 use merklize::{StateRootHash, StateTree};
 
 #[open_rpc(namespace = "flk", tag = "1.0.0")]
@@ -220,19 +220,12 @@ pub trait FleekApi {
     #[method(name = "metrics")]
     async fn metrics(&self) -> RpcResult<String>;
 
-    #[method(name = "get_flk_withdraws")]
-    async fn get_flk_withdraws(
+    #[method(name = "get_withdraws")]
+    async fn get_withdraws(
         &self,
         epoch: Option<u64>,
         paging: WithdrawPagingParams,
-    ) -> RpcResult<Vec<(u64, EthAddress, HpUfixed<18>)>>;
-
-    #[method(name = "get_usdc_withdraws")]
-    async fn get_usdc_withdraws(
-        &self,
-        epoch: Option<u64>,
-        paging: WithdrawPagingParams,
-    ) -> RpcResult<Vec<(u64, EthAddress, HpUfixed<6>)>>;
+    ) -> RpcResult<Vec<WithdrawInfoWithId>>;
 
     #[subscription(name = "subscribe", item = Event)]
     async fn handle_subscription(&self, event_type: Option<EventType>) -> SubscriptionResult;

--- a/core/rpc/src/logic/flk_impl.rs
+++ b/core/rpc/src/logic/flk_impl.rs
@@ -33,7 +33,7 @@ use lightning_types::{AggregateCheckpoint, StateProofKey, StateProofValue};
 use lightning_utils::application::QueryRunnerExt;
 use merklize::{StateRootHash, StateTree};
 use serde_json::Value as JsonValue;
-use types::ProtocolParamKey;
+use types::{ProtocolParamKey, WithdrawInfoWithId};
 
 use crate::api::FleekApiServer;
 use crate::error::RPCError;
@@ -468,28 +468,12 @@ impl<C: NodeComponents> FleekApiServer for FleekApi<C> {
         }
     }
 
-    async fn get_flk_withdraws(
+    async fn get_withdraws(
         &self,
         epoch: Option<u64>,
         paging: WithdrawPagingParams,
-    ) -> RpcResult<Vec<(u64, EthAddress, HpUfixed<18>)>> {
-        Ok(self
-            .data
-            .query_runner(epoch)
-            .await?
-            .get_flk_withdraws(paging))
-    }
-
-    async fn get_usdc_withdraws(
-        &self,
-        epoch: Option<u64>,
-        paging: WithdrawPagingParams,
-    ) -> RpcResult<Vec<(u64, EthAddress, HpUfixed<6>)>> {
-        Ok(self
-            .data
-            .query_runner(epoch)
-            .await?
-            .get_usdc_withdraws(paging))
+    ) -> RpcResult<Vec<WithdrawInfoWithId>> {
+        Ok(self.data.query_runner(epoch).await?.get_withdraws(paging))
     }
 
     async fn handle_subscription(

--- a/core/types/src/application.rs
+++ b/core/types/src/application.rs
@@ -7,7 +7,7 @@ use fleek_crypto::{EthAddress, NodePublicKey};
 use hp_fixed::unsigned::HpUfixed;
 use serde::{Deserialize, Serialize};
 
-use crate::{BlockNumber, Staking, TransactionReceipt};
+use crate::{BlockNumber, Epoch, Staking, Tokens, TransactionReceipt};
 
 /// Max number of updates allowed in a content registry update transaction.
 pub const MAX_UPDATES_CONTENT_REGISTRY: usize = 100;
@@ -210,4 +210,18 @@ pub struct AccountInfo {
     /// The nonce of the account. Added to each transaction before signed to prevent replays and
     /// enforce ordering
     pub nonce: u64,
+}
+
+#[derive(Debug, Hash, Serialize, Deserialize, Clone, schemars::JsonSchema)]
+pub struct WithdrawInfo {
+    pub epoch: Epoch,
+    pub token: Tokens,
+    pub receiver: EthAddress,
+    pub amount: HpUfixed<18>,
+}
+
+#[derive(Debug, Hash, Serialize, Deserialize, Clone, schemars::JsonSchema)]
+pub struct WithdrawInfoWithId {
+    pub id: u64,
+    pub info: WithdrawInfo,
 }


### PR DESCRIPTION
This merges the two withdraw state tables and also introduces types to avoid using tuples.