### PR TITLE
test(e2e): blockstore server test

### DIFF
--- a/core/e2e/src/containerized_node.rs
+++ b/core/e2e/src/containerized_node.rs
@@ -108,6 +108,13 @@ impl ContainerizedNode {
             .clone()
     }
 
+    pub fn take_blockstore_server_socket(&self) -> BlockstoreServerSocket {
+        self.node
+            .provider()
+            .get::<<FullNodeComponents as NodeComponents>::BlockstoreServerInterface>()
+            .get_socket()
+    }
+
     pub fn is_genesis_committee(&self) -> bool {
         self.is_genesis_committee
     }

--- a/core/e2e/src/swarm.rs
+++ b/core/e2e/src/swarm.rs
@@ -179,8 +179,21 @@ impl Swarm {
         self.nodes.get(node).map(|node| node.take_blockstore())
     }
 
+    pub fn get_blockstore_server_socket(
+        &self,
+        node: &NodePublicKey,
+    ) -> Option<BlockstoreServerSocket> {
+        self.nodes
+            .get(node)
+            .map(|node| node.take_blockstore_server_socket())
+    }
+
     pub fn nodes(&self) -> Vec<&ContainerizedNode> {
         self.nodes.values().collect::<Vec<_>>()
+    }
+
+    pub fn get_node_index(&self, node: &NodePublicKey) -> Option<NodeIndex> {
+        self.nodes.get(node).map(|node| node.get_index())
     }
 
     pub fn started_nodes(&self) -> Vec<&ContainerizedNode> {

--- a/core/e2e/tests/blockstore_server.rs
+++ b/core/e2e/tests/blockstore_server.rs
@@ -1,0 +1,83 @@
+use std::time::{Duration, SystemTime};
+
+use fleek_blake3 as blake3;
+use fleek_crypto::NodePublicKey;
+use lightning_blockstore::blockstore::BLOCK_SIZE;
+use lightning_e2e::swarm::Swarm;
+use lightning_interfaces::prelude::*;
+use lightning_interfaces::types::{CompressionAlgorithm, ServerRequest};
+use lightning_test_utils::logging;
+use tempfile::tempdir;
+
+fn create_content() -> Vec<u8> {
+    (0..4)
+        .map(|i| Vec::from([i; BLOCK_SIZE]))
+        .flat_map(|a| a.into_iter())
+        .collect()
+}
+
+#[tokio::test]
+async fn e2e_blockstore_server_get() {
+    logging::setup();
+
+    let temp_dir = tempdir().unwrap();
+    let mut swarm = Swarm::builder()
+        .with_directory(temp_dir.path().to_path_buf().try_into().unwrap())
+        .with_min_port(10700)
+        .with_num_nodes(4)
+        // We need to include enough time in this epoch time for the nodes to start up, or else it
+        // begins the epoch change immediately when they do. We can even get into a situation where
+        // another epoch change starts quickly after that, causing our expectation of epoch = 1
+        // below to fail.
+        .with_epoch_time(10000)
+        .with_epoch_start(
+            SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_millis() as u64,
+        )
+        .with_syncronizer_delta(Duration::from_secs(5))
+        .build();
+    swarm.launch().await.unwrap();
+
+    // Wait for RPC to be ready.
+    swarm.wait_for_rpc_ready().await;
+
+    let pubkeys: Vec<NodePublicKey> = swarm.get_ports().keys().cloned().collect();
+    let pubkey1 = pubkeys[0];
+    let pubkey2 = pubkeys[1];
+    let index1 = swarm.get_node_index(&pubkey1).unwrap();
+
+    // Put some data into the blockstore of node1
+    let data = create_content();
+    let blockstore1 = swarm.get_blockstore(&pubkey1).unwrap();
+    let mut putter = blockstore1.put(None);
+    putter
+        .write(data.as_slice(), CompressionAlgorithm::Uncompressed)
+        .unwrap();
+    let data_hash = putter.finalize().await.unwrap();
+
+    // Send a request from node2 to node1 to obtain the data
+    let blockstore2 = swarm.get_blockstore(&pubkey2).unwrap();
+    let blockstore_server_socket2 = swarm.get_blockstore_server_socket(&pubkey2).unwrap();
+
+    let mut res = blockstore_server_socket2
+        .run(ServerRequest {
+            hash: data_hash,
+            peer: index1,
+        })
+        .await
+        .expect("Failed to send request");
+    match res.recv().await.unwrap() {
+        Ok(()) => {
+            // Make sure the data matches
+            let recv_data = blockstore2.read_all_to_vec(&data_hash).await.unwrap();
+            assert_eq!(data, recv_data);
+            let hash = blake3::hash(&recv_data);
+            assert_eq!(hash, data_hash);
+        },
+        Err(e) => panic!("Failed to receive content: {e:?}"),
+    }
+
+    swarm.shutdown().await;
+}


### PR DESCRIPTION
This add a e2e test for the blockstore server. We spawn a swarm of nodes, put data into node1's blockstore. Then send a request from node2's blockstore server to node1, and make sure that the data matches.