### PR TITLE
chore(test-utils): pass path to logger to log to file

### DIFF
--- a/core/broadcast/src/tests.rs
+++ b/core/broadcast/src/tests.rs
@@ -138,7 +138,7 @@ async fn create_peer(
 
 #[tokio::test]
 async fn test_send() {
-    lightning_test_utils::logging::setup();
+    lightning_test_utils::logging::setup(None);
 
     let temp_dir = tempdir().unwrap();
 

--- a/core/broadcast/tests/broadcast.rs
+++ b/core/broadcast/tests/broadcast.rs
@@ -309,7 +309,7 @@ where
 
 #[test]
 fn demo() {
-    logging::setup();
+    logging::setup(None);
 
     let (pubsub, backend) = spawn_context(ONE_HOUR);
 

--- a/core/e2e/src/bin/spawn_swarm.rs
+++ b/core/e2e/src/bin/spawn_swarm.rs
@@ -45,7 +45,7 @@ struct Cli {
 }
 
 fn main() -> Result<()> {
-    logging::setup();
+    logging::setup(None);
 
     let args = Cli::parse();
 

--- a/core/e2e/tests/blockstore_server.rs
+++ b/core/e2e/tests/blockstore_server.rs
@@ -18,7 +18,7 @@ fn create_content() -> Vec<u8> {
 
 #[tokio::test]
 async fn e2e_blockstore_server_get() {
-    logging::setup();
+    logging::setup(None);
 
     let temp_dir = tempdir().unwrap();
     let mut swarm = Swarm::builder()

--- a/core/e2e/tests/checkpoint.rs
+++ b/core/e2e/tests/checkpoint.rs
@@ -10,7 +10,7 @@ use tempfile::tempdir;
 
 #[tokio::test]
 async fn e2e_checkpoint() {
-    logging::setup();
+    logging::setup(None);
 
     let temp_dir = tempdir().unwrap();
     let mut swarm = Swarm::builder()

--- a/core/e2e/tests/epoch_change.rs
+++ b/core/e2e/tests/epoch_change.rs
@@ -12,7 +12,7 @@ use tempfile::tempdir;
 
 #[tokio::test]
 async fn e2e_epoch_change_all_nodes_on_committee() {
-    logging::setup();
+    logging::setup(None);
 
     // Initialize the swarm.
     let temp_dir = tempdir().unwrap();
@@ -60,7 +60,7 @@ async fn e2e_epoch_change_all_nodes_on_committee() {
 
 #[tokio::test]
 async fn e2e_epoch_change_with_some_nodes_not_on_committee() {
-    logging::setup();
+    logging::setup(None);
 
     // Initialize the swarm.
     let temp_dir = tempdir().unwrap();
@@ -128,7 +128,7 @@ async fn e2e_epoch_change_with_some_nodes_not_on_committee() {
 
 #[tokio::test]
 async fn e2e_test_staking_auction() {
-    logging::setup();
+    logging::setup(None);
 
     // Set a node with high rep and a slightly lower stake then everyone else
     let high_rep_node = SwarmNode {

--- a/core/e2e/tests/pinger.rs
+++ b/core/e2e/tests/pinger.rs
@@ -9,7 +9,7 @@ use tempfile::tempdir;
 
 #[tokio::test]
 async fn e2e_detect_offline_node() {
-    logging::setup();
+    logging::setup(None);
 
     let temp_dir = tempdir().unwrap();
     let mut swarm = Swarm::builder()

--- a/core/e2e/tests/syncronizer.rs
+++ b/core/e2e/tests/syncronizer.rs
@@ -8,7 +8,7 @@ use tempfile::tempdir;
 
 #[tokio::test]
 async fn e2e_syncronize_state() {
-    logging::setup();
+    logging::setup(None);
 
     let temp_dir = tempdir().unwrap();
     let mut swarm = Swarm::builder()

--- a/core/task-broker/src/tests.rs
+++ b/core/task-broker/src/tests.rs
@@ -221,7 +221,7 @@ async fn run_local_echo_task() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn run_single_echo_task() -> anyhow::Result<()> {
-    lightning_test_utils::logging::setup();
+    lightning_test_utils::logging::setup(None);
     let (_, mut nodes) = build_cluster(4).await?;
 
     let broker = nodes[0].provider.get::<TaskBroker<TestBinding>>();
@@ -268,7 +268,7 @@ async fn run_single_echo_task() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn run_single_echo_task_with_fallback() -> anyhow::Result<()> {
-    lightning_test_utils::logging::setup();
+    lightning_test_utils::logging::setup(None);
     let (_, mut nodes) = build_cluster(4).await?;
 
     // shutdown all nodes except 2; one to perform the request,
@@ -326,7 +326,7 @@ async fn run_single_echo_task_with_fallback() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn run_cluster_echo_task() -> anyhow::Result<()> {
-    lightning_test_utils::logging::setup();
+    lightning_test_utils::logging::setup(None);
     let (_, mut nodes) = build_cluster(8).await?;
 
     let broker = nodes[0].provider.get::<TaskBroker<TestBinding>>();
@@ -368,7 +368,7 @@ async fn run_cluster_echo_task() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn run_cluster_echo_task_1_offline_of_8() -> anyhow::Result<()> {
-    lightning_test_utils::logging::setup();
+    lightning_test_utils::logging::setup(None);
     let (_, mut nodes) = build_cluster(8).await?;
 
     // shutdown a node
@@ -421,7 +421,7 @@ async fn run_cluster_echo_task_1_offline_of_8() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn run_cluster_echo_task_7_offline_of_8_should_fail() -> anyhow::Result<()> {
-    lightning_test_utils::logging::setup();
+    lightning_test_utils::logging::setup(None);
     let (_, mut nodes) = build_cluster(8).await?;
 
     // shutdown all nodes but one

--- a/core/test-utils/src/logging.rs
+++ b/core/test-utils/src/logging.rs
@@ -74,11 +74,7 @@ pub fn setup(log_file_path: Option<PathBuf>) {
                         TerminalMode::Mixed,
                         ColorChoice::Auto,
                     ),
-                    WriteLogger::new(
-                        LevelFilter::Trace,
-                        config,
-                        File::create(log_file_path).unwrap(),
-                    ),
+                    WriteLogger::new(log_filter, config, File::create(log_file_path).unwrap()),
                 ]);
             } else {
                 let _ = CombinedLogger::init(vec![TermLogger::new(


### PR DESCRIPTION
This enables passing a path to the logger so that logs are written to that file. This only concerns e2e tests and some other tests. The logger for the lightning binary is somewhere else.