### PR TITLE
app: implement eth abi client key mgmt and layout client nonces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7673,6 +7673,7 @@ dependencies = [
  "b3fs",
  "cid",
  "clap",
+ "ethers",
  "fleek-blake3",
  "fleek-crypto",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6211,7 +6211,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.7",
  "tokio",
  "tower-service",
  "tracing",
@@ -17467,9 +17467,9 @@ checksum = "47f9da296a88b6bc150b896d17770a62d4dc6f63ecf0ed10a9c08a1cb3d12f24"
 
 [[package]]
 name = "xxhash-rust"
-version = "0.8.12"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a5cbf750400958819fb6178eaa83bee5cd9c29a26a40cc241df8c70fdd46984"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yaml-rust"

--- a/core/application/src/state/executor.rs
+++ b/core/application/src/state/executor.rs
@@ -1163,6 +1163,11 @@ impl<B: Backend> StateExecutor<B> {
         }
         account_info.client_key = Some(ClientPublicKey(client_key));
 
+        // TODO(oz): technically we should track the client key -> accout key here, but I think
+        //           the pod flow will change to where the client declares the eth account id
+        //           it will use on connection or even per dack. Need to finalize this flow, but
+        //           tracking the logic and ensuring a 1-1 is slightly complex and unused for now.
+
         // Commit to state and return success
         self.account_info.set(sender, account_info);
         TransactionResponse::Success(ExecutionData::None)

--- a/core/application/src/state/query.rs
+++ b/core/application/src/state/query.rs
@@ -190,6 +190,18 @@ impl SyncQueryRunnerInterface for QueryRunner {
     }
 
     #[inline]
+    fn get_client_nonce(&self, pub_key: &ClientPublicKey) -> Nonce {
+        self.inner
+            .run(|ctx| {
+                self.client_table
+                    .get(ctx)
+                    .get(pub_key)
+                    .map(|(_, nonce)| nonce)
+            })
+            .unwrap_or_default()
+    }
+
+    #[inline]
     fn get_node_info<V>(
         &self,
         node: &NodeIndex,

--- a/core/application/src/state/writer.rs
+++ b/core/application/src/state/writer.rs
@@ -164,7 +164,7 @@ impl ApplicationState<AtomoStorage, DefaultSerdeBackend, ApplicationStateTree> {
         let mut builder = builder
             .with_table::<Metadata, Value>("metadata")
             .with_table::<EthAddress, AccountInfo>("account")
-            .with_table::<ClientPublicKey, EthAddress>("client_keys")
+            .with_table::<ClientPublicKey, (EthAddress, u64)>("client_keys")
             .with_table::<NodeIndex, NodeInfo>("node")
             .with_table::<ConsensusPublicKey, NodeIndex>("consensus_key_to_index")
             .with_table::<NodePublicKey, NodeIndex>("pub_key_to_index")
@@ -243,15 +243,7 @@ mod tests {
                     let public_key = secret_key.to_pk();
                     let eth_address: EthAddress = public_key.into();
 
-                    (
-                        eth_address,
-                        AccountInfo {
-                            flk_balance: HpUfixed::<18>::zero(),
-                            stables_balance: HpUfixed::<6>::zero(),
-                            bandwidth_balance: 0,
-                            nonce: 0,
-                        },
-                    )
+                    (eth_address, AccountInfo::default())
                 })
                 .collect::<Vec<_>>();
             let nodes = (0..node_count)

--- a/core/e2e/Cargo.toml
+++ b/core/e2e/Cargo.toml
@@ -49,6 +49,7 @@ serial_test = "3.0.0"
 tracing.workspace = true
 fleek-blake3 = "1.5"
 thiserror.workspace = true
+ethers.workspace = true
 
 toml = "0.7"
 resolve-path = "0.1.0"

--- a/core/e2e/src/containerized_node.rs
+++ b/core/e2e/src/containerized_node.rs
@@ -122,6 +122,15 @@ impl ContainerizedNode {
             .get_socket()
     }
 
+    pub fn take_cloned_query_runner(
+        &self,
+    ) -> c!(FullNodeComponents::ApplicationInterface::SyncExecutor) {
+        self.node
+            .provider()
+            .get::<c!(FullNodeComponents::ApplicationInterface::SyncExecutor)>()
+            .clone()
+    }
+
     pub fn is_genesis_committee(&self) -> bool {
         self.is_genesis_committee
     }

--- a/core/e2e/src/swarm.rs
+++ b/core/e2e/src/swarm.rs
@@ -141,6 +141,15 @@ impl Swarm {
             .collect()
     }
 
+    pub fn get_query_runners(
+        &self,
+    ) -> HashMap<NodePublicKey, c!(FullNodeComponents::ApplicationInterface::SyncExecutor)> {
+        self.nodes
+            .iter()
+            .map(|(&pubkey, node)| (pubkey, node.take_cloned_query_runner()))
+            .collect()
+    }
+
     pub fn get_genesis_committee_rpc_addresses(&self) -> HashMap<NodePublicKey, String> {
         self.nodes
             .iter()
@@ -298,6 +307,7 @@ pub struct SwarmBuilder {
     ping_interval: Option<Duration>,
     ping_timeout: Option<Duration>,
     ipfs_gateways: Option<Vec<Gateway>>,
+    chain_id: Option<u32>,
 }
 
 impl SwarmBuilder {
@@ -387,6 +397,11 @@ impl SwarmBuilder {
         self
     }
 
+    pub fn with_chain_id(mut self, chain_id: u32) -> Self {
+        self.chain_id = Some(chain_id);
+        self
+    }
+
     pub fn build(self) -> Swarm {
         let num_nodes = self.num_nodes.expect("Number of nodes must be provided.");
         let directory = self.directory.expect("Directory must be provided.");
@@ -416,7 +431,7 @@ impl SwarmBuilder {
             max_lock_time: 1460,
             supply_at_genesis: 1000000,
             min_num_measurements: 2,
-            chain_id: 59330,
+            chain_id: self.chain_id.unwrap_or(1337),
             reputation_ping_timeout: self.ping_timeout.unwrap_or(Duration::from_millis(1)),
             topology_target_k: 8,
             topology_min_nodes: 16,

--- a/core/e2e/tests/eth.rs
+++ b/core/e2e/tests/eth.rs
@@ -1,0 +1,137 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use ethers::middleware::SignerMiddleware;
+use ethers::providers::Middleware;
+use ethers::signers::{LocalWallet, Signer};
+use fleek_crypto::{AccountOwnerSecretKey, EthAddress, SecretKey};
+use lightning_e2e::swarm::Swarm;
+use lightning_interfaces::_SyncQueryRunnerInterface;
+use lightning_test_utils::logging;
+use lightning_utils::eth::FleekContract;
+use lightning_utils::poll::poll_until;
+use tempfile::tempdir;
+
+#[tokio::test]
+async fn e2e_eth_client_approve_revoke() {
+    logging::setup(None);
+
+    let temp_dir = tempdir().unwrap();
+    let chain_id = 1337;
+    let mut swarm = Swarm::builder()
+        .with_directory(temp_dir.path().to_path_buf().try_into().unwrap())
+        .with_min_port(10000)
+        .with_num_nodes(4)
+        .with_chain_id(chain_id)
+        .persistence(true)
+        .with_archiver()
+        .build();
+    swarm.launch().await.unwrap();
+
+    // Wait for RPC to be ready.
+    swarm.wait_for_rpc_ready().await;
+
+    // give forwarder some time to connect
+    // TODO: this shouldn't be needed, but something is weird with the start of each epoch
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let rpc_addr = swarm.get_rpc_addresses().into_iter().next().unwrap().1;
+
+    let provider = ethers::providers::Provider::<ethers::providers::Http>::try_from(rpc_addr)
+        .expect("to connect to node rpc");
+
+    let secret = AccountOwnerSecretKey::generate();
+    let account_pk: EthAddress = secret.to_pk().into();
+    let wallet = LocalWallet::from_bytes(&secret.into_bytes()).unwrap();
+    let client = Arc::new(SignerMiddleware::new(provider.clone(), wallet.clone()));
+
+    let contract = FleekContract::new(
+        "0x0606060606060606060606060606060606060606"
+            .parse::<ethers::types::Address>()
+            .unwrap(),
+        client.clone(),
+    );
+
+    // create a client key
+    let client_key = fleek_crypto::ClientSecretKey::generate();
+    let client_pk = client_key.to_pk();
+
+    // Create a transaction for the client key approval, sign, and send it to the node
+    let mut tx = contract.approve_client_key(client_pk.0.into()).tx;
+    tx.set_chain_id(chain_id);
+    tx.set_nonce(1);
+    let sig = client
+        .sign_transaction(&tx, wallet.address())
+        .await
+        .unwrap();
+    let res = provider
+        .send_raw_transaction(tx.rlp_signed(&sig))
+        .await
+        .unwrap();
+
+    // poll for a transaction receipt
+    // TODO: correctly provide eth_getTransactionByHash so we can just await the pending
+    // transaction with ethers contract abstraction
+    let _receipt = poll_until(
+        || async {
+            provider
+                .get_transaction_receipt(res.0)
+                .await
+                .ok()
+                .flatten()
+                .ok_or(lightning_utils::poll::PollUntilError::ConditionNotSatisfied)
+        },
+        Duration::from_secs(10),
+        Duration::from_millis(500),
+    )
+    .await
+    .unwrap();
+    assert_eq!(_receipt.status, Some(1.into()));
+
+    // grab a query runner and ensure the client key is set to the desired key
+    let (_, query) = swarm.get_query_runners().into_iter().next().unwrap();
+    let app_client_key = query
+        .get_account_info(&account_pk, |x| x.client_key)
+        .unwrap();
+    assert_eq!(app_client_key, Some(client_pk));
+
+    // Create a transaction for the client key revokation, sign, and send it to the node
+    let mut tx = contract.revoke_client_key().tx;
+    tx.set_chain_id(chain_id);
+    tx.set_nonce(2);
+    let sig = client
+        .sign_transaction(&tx, wallet.address())
+        .await
+        .unwrap();
+    let res = provider
+        .send_raw_transaction(tx.rlp_signed(&sig))
+        .await
+        .unwrap();
+
+    // poll for a transaction receipt
+    // TODO: correctly provide eth_getTransactionByHash so we can just await the pending
+    // transaction with ethers contract abstraction
+    let _receipt = poll_until(
+        || async {
+            provider
+                .get_transaction_receipt(res.0)
+                .await
+                .ok()
+                .flatten()
+                .ok_or(lightning_utils::poll::PollUntilError::ConditionNotSatisfied)
+        },
+        Duration::from_secs(10),
+        Duration::from_millis(500),
+    )
+    .await
+    .unwrap();
+    assert_eq!(_receipt.status, Some(1.into()));
+
+    // ensure the client key has been cleared
+    let app_client_key = query
+        .get_account_info(&account_pk, |x| x.client_key)
+        .unwrap();
+    assert_eq!(app_client_key, None);
+
+    swarm.shutdown().await;
+}

--- a/core/interfaces/src/application.rs
+++ b/core/interfaces/src/application.rs
@@ -17,6 +17,7 @@ use lightning_types::{
     CommitteeSelectionBeaconReveal,
     Genesis,
     NodeIndex,
+    Nonce,
     ProtocolParamKey,
     ProtocolParamValue,
     StateProofKey,
@@ -127,8 +128,11 @@ pub trait SyncQueryRunnerInterface: Clone + Send + Sync + 'static {
         selector: impl FnOnce(AccountInfo) -> V,
     ) -> Option<V>;
 
-    /// Query Client Table
+    /// Query Client table for parent account id
     fn client_key_to_account_key(&self, pub_key: &ClientPublicKey) -> Option<EthAddress>;
+
+    /// Query Client table for nonce
+    fn get_client_nonce(&self, pub_key: &ClientPublicKey) -> Nonce;
 
     /// Query Node Table
     /// Returns information about a single node.

--- a/core/rpc/src/tests.rs
+++ b/core/rpc/src/tests.rs
@@ -801,6 +801,7 @@ async fn test_rpc_get_state_proof() {
             stables_balance: HpUfixed::zero(),
             bandwidth_balance: 0,
             nonce: 0,
+            client_key: None,
         })
     );
 
@@ -815,6 +816,7 @@ async fn test_rpc_get_state_proof() {
                 stables_balance: HpUfixed::zero(),
                 bandwidth_balance: 0,
                 nonce: 0,
+                client_key: None,
             },
             root_hash,
         )

--- a/core/types/src/application.rs
+++ b/core/types/src/application.rs
@@ -3,7 +3,7 @@
 use std::collections::BTreeMap;
 
 use ethers::types::{Block as EthersBlock, H256, U64};
-use fleek_crypto::{EthAddress, NodePublicKey};
+use fleek_crypto::{ClientPublicKey, EthAddress, NodePublicKey};
 use hp_fixed::unsigned::HpUfixed;
 use serde::{Deserialize, Serialize};
 
@@ -210,6 +210,8 @@ pub struct AccountInfo {
     /// The nonce of the account. Added to each transaction before signed to prevent replays and
     /// enforce ordering
     pub nonce: u64,
+    /// Approved client public keys
+    pub client_key: Option<ClientPublicKey>,
 }
 
 #[derive(Debug, Hash, PartialEq, Serialize, Deserialize, Clone, schemars::JsonSchema)]

--- a/core/types/src/response.rs
+++ b/core/types/src/response.rs
@@ -165,4 +165,8 @@ pub enum ExecutionError {
     TooManyMeasurements,
     TooManyUpdates,
     TooManyUpdatesForContent,
+    // approve and revoke client key error types
+    InvalidClientKeyLength,
+    DuplicateClientKey,
+    MissingClientKey,
 }

--- a/core/utils/src/eth.rs
+++ b/core/utils/src/eth.rs
@@ -11,6 +11,8 @@ abigen!(
         function deposit(string token, uint256 amount)
         function unstake(uint256 amount, bytes32 node_public_key)
         function withdrawUnstaked(bytes32 node_public_key, address recipient)
+        function approveClientKey(bytes client_key)
+        function revokeClientKey()
     ]"
 );
 

--- a/lib/fleek-crypto/src/keys/mod.rs
+++ b/lib/fleek-crypto/src/keys/mod.rs
@@ -2,4 +2,4 @@ mod pk;
 mod sk;
 
 pub use pk::*;
-pub use sk::{AccountOwnerSecretKey, ConsensusSecretKey, NodeSecretKey};
+pub use sk::{AccountOwnerSecretKey, ClientSecretKey, ConsensusSecretKey, NodeSecretKey};

--- a/lib/fleek-crypto/src/keys/sk/account.rs
+++ b/lib/fleek-crypto/src/keys/sk/account.rs
@@ -35,6 +35,12 @@ impl From<&AccountOwnerSecretKey> for Secp256k1PrivateKey {
     }
 }
 
+impl AccountOwnerSecretKey {
+    pub fn into_bytes(self) -> [u8; 32] {
+        self.0
+    }
+}
+
 impl SecretKey for AccountOwnerSecretKey {
     type PublicKey = AccountOwnerPublicKey;
 

--- a/lib/fleek-crypto/src/keys/sk/client.rs
+++ b/lib/fleek-crypto/src/keys/sk/client.rs
@@ -1,0 +1,72 @@
+use arrayref::array_ref;
+use fastcrypto::bls12381::min_sig::{BLS12381KeyPair, BLS12381PrivateKey, BLS12381PublicKey};
+use fastcrypto::traits::{KeyPair, Signer, ToFromBytes};
+use rand::rngs::ThreadRng;
+use sec1::{pem, LineEnding};
+use zeroize::{Zeroize, ZeroizeOnDrop};
+
+use super::super::pk::ClientPublicKey;
+use crate::{PublicKey, SecretKey};
+
+const BLS12_381_PEM_LABEL: &str = "LIGHTNING BLS12_381 PRIVATE KEY";
+
+#[derive(Clone, PartialEq, Zeroize, ZeroizeOnDrop)]
+pub struct ClientSecretKey([u8; 32]);
+
+impl std::fmt::Debug for ClientSecretKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("ClientSecretKeyOf")
+            .field(&self.to_pk())
+            .finish()
+    }
+}
+
+impl From<BLS12381PrivateKey> for ClientSecretKey {
+    fn from(value: BLS12381PrivateKey) -> Self {
+        let bytes = value.as_ref();
+        ClientSecretKey(*array_ref!(bytes, 0, 32))
+    }
+}
+
+impl From<&ClientSecretKey> for BLS12381PrivateKey {
+    fn from(value: &ClientSecretKey) -> Self {
+        BLS12381PrivateKey::from_bytes(&value.0).unwrap()
+    }
+}
+
+impl From<ClientSecretKey> for BLS12381KeyPair {
+    fn from(value: ClientSecretKey) -> Self {
+        BLS12381PrivateKey::from(&value).into()
+    }
+}
+
+impl SecretKey for ClientSecretKey {
+    type PublicKey = ClientPublicKey;
+
+    fn generate() -> Self {
+        let pair = BLS12381KeyPair::generate(&mut ThreadRng::default());
+        pair.private().into()
+    }
+
+    fn decode_pem(encoded: &str) -> Option<ClientSecretKey> {
+        let (label, bytes) = pem::decode_vec(encoded.as_bytes()).ok()?;
+        (label == BLS12_381_PEM_LABEL && bytes.len() == 32)
+            .then(|| ClientSecretKey(*array_ref!(bytes, 0, 32)))
+    }
+
+    fn encode_pem(&self) -> String {
+        pem::encode_string(BLS12_381_PEM_LABEL, LineEnding::LF, &self.0).unwrap()
+    }
+
+    /// Sign a raw message.
+    fn sign(&self, msg: &[u8]) -> <Self::PublicKey as PublicKey>::Signature {
+        let secret: BLS12381PrivateKey = self.into();
+        secret.sign(msg).into()
+    }
+
+    fn to_pk(&self) -> Self::PublicKey {
+        let secret: &BLS12381PrivateKey = &self.into();
+        let pubkey: BLS12381PublicKey = secret.into();
+        pubkey.into()
+    }
+}

--- a/lib/fleek-crypto/src/keys/sk/mod.rs
+++ b/lib/fleek-crypto/src/keys/sk/mod.rs
@@ -1,7 +1,9 @@
 mod account;
+mod client;
 mod consensus;
 mod node;
 
 pub use account::AccountOwnerSecretKey;
+pub use client::ClientSecretKey;
 pub use consensus::ConsensusSecretKey;
 pub use node::NodeSecretKey;


### PR DESCRIPTION
Adds client key management to ethereum account owners.

- Approve and revoke eth contract methods
- state transition functions
- e2e testing for eth (for now just whats added here)
- add client secret key to fleek-crypto
- add client nonce to client table
- left outstanding todo and explaination on client->account map not being set for now (need to decide on pod flow change)

> note: no app state fallback so requires fork on testnet