### PR TITLE
handshake: implement (togglable) pop verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5107,6 +5107,7 @@ dependencies = [
  "arrayref",
  "bytes",
  "cid",
+ "fleek-crypto",
  "fn-sdk",
  "hex",
  "lightning-schema",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8380,6 +8380,7 @@ dependencies = [
  "lightning-types",
  "lightning-workspace-hack",
  "serde",
+ "sha2 0.10.8",
 ]
 
 [[package]]

--- a/core/handshake/benches/mock.rs
+++ b/core/handshake/benches/mock.rs
@@ -72,6 +72,8 @@ async fn perform_handshake(tx: &Sender<Bytes>, rx: &mut Receiver<Bytes>) {
         schema::HandshakeRequestFrame::Handshake {
             retry: None,
             service: 1001,
+            expiry: u64::MAX,
+            nonce: 789,
             pk: ClientPublicKey([1; 96]),
             pop: ClientSignature([2; 48]),
         }
@@ -121,6 +123,8 @@ fn run_clients(n: usize) -> Vec<JoinHandle<()>> {
                         schema::HandshakeRequestFrame::Handshake {
                             retry: None,
                             service: 1001,
+                            expiry: u64::MAX,
+                            nonce: 789,
                             pk: ClientPublicKey([1; 96]),
                             pop: ClientSignature([2; 48]),
                         }

--- a/core/handshake/examples/tcp-stress.rs
+++ b/core/handshake/examples/tcp-stress.rs
@@ -2,6 +2,7 @@ use std::fs::File;
 use std::io::Write;
 use std::net::{IpAddr, SocketAddr};
 use std::path::PathBuf;
+use std::time::SystemTime;
 
 use anyhow::{anyhow, Result};
 use clap::Parser;
@@ -223,6 +224,12 @@ async fn run_request(
             service: 1001,
             pk: ClientPublicKey([1; 96]),
             pop: ClientSignature([2; 48]),
+            expiry: SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_secs()
+                + 3600,
+            nonce: 0,
         })
         .await?;
     data!(line, "handshake_sent", timer);

--- a/core/handshake/src/config.rs
+++ b/core/handshake/src/config.rs
@@ -9,6 +9,8 @@ use crate::transports;
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(default)]
 pub struct HandshakeConfig {
+    /// Enable validating client pop signatures
+    pub validate: bool,
     /// List of transports to enable
     #[serde(rename = "transport")]
     pub transports: Vec<TransportConfig>,
@@ -24,6 +26,7 @@ pub struct HandshakeConfig {
 impl Default for HandshakeConfig {
     fn default() -> Self {
         Self {
+            validate: false, // disabled by default until gateway is ready
             transports: vec![
                 TransportConfig::WebRTC(Default::default()),
                 TransportConfig::WebTransport(Default::default()),

--- a/core/handshake/src/handshake.rs
+++ b/core/handshake/src/handshake.rs
@@ -246,19 +246,15 @@ impl<P: ExecutorProviderInterface, QR: SyncQueryRunnerInterface> Context<P, QR> 
                         return;
                     }
 
-                    // 5. Encode and send the handshake response, signing the handshake digest from
-                    //    the client we just validated.
+                    // 5. Finally send the handshake response, signing the handshake digest from the
+                    //    client we just validated.
                     // TODO: again should we avoid double hashing here
-                    let res = HandshakeResponse {
-                        pk: self.pk,
-                        pop: self.sk.sign(&digest),
-                    }
-                    .encode();
-                    sender.start_write(res.len()).await;
-                    if let Err(e) = sender.write(res).await {
-                        warn!("failed to send handshake response frame: {e}");
-                        return;
-                    };
+                    sender
+                        .send_handshake_response(HandshakeResponse {
+                            pk: self.pk,
+                            pop: self.sk.sign(&digest),
+                        })
+                        .await;
                 }
 
                 // Attempt to connect to the service, getting the unix socket.

--- a/core/handshake/src/proxy.rs
+++ b/core/handshake/src/proxy.rs
@@ -560,6 +560,7 @@ mod tests {
     };
     use lightning_interfaces::types::ServiceId;
     use lightning_interfaces::ShutdownController;
+    use lightning_test_utils::keys::EphemeralKeystore;
     use tokio::net::UnixStream;
     use tokio::time::timeout;
     use tokio_util::codec::Framed;
@@ -609,9 +610,17 @@ mod tests {
         }
     }
 
+    partial_node_components!(MockNode {
+        KeystoreInterface = EphemeralKeystore<Self>;
+    });
+
     async fn start_mock_node(id: u16) -> Result<ShutdownController> {
         let shutdown = ShutdownController::default();
+        let keystore = EphemeralKeystore::<MockNode>::default();
+
         let context = Context::new(
+            keystore.get_ed25519_pk(),
+            keystore.get_ed25519_sk(),
             MockServiceProvider,
             lightning_interfaces::_hacks::Blanket,
             shutdown.waiter(),

--- a/core/handshake/src/transports/mock.rs
+++ b/core/handshake/src/transports/mock.rs
@@ -68,7 +68,7 @@ impl Transport for MockTransport {
     type Sender = MockTransportSender;
     type Receiver = MockTransportReceiver;
 
-    async fn bind<P: ExecutorProviderInterface>(
+    async fn bind(
         _waiter: ShutdownWaiter,
         config: Self::Config,
     ) -> anyhow::Result<(Self, Option<Router>)> {
@@ -170,7 +170,6 @@ impl TransportReceiver for MockTransportReceiver {
 mod tests {
     use fleek_crypto::{ClientPublicKey, ClientSignature};
     use lightning_interfaces::ShutdownController;
-    use lightning_service_executor::shim::Provider;
 
     use super::*;
 
@@ -179,8 +178,7 @@ mod tests {
         let notifier = ShutdownController::default();
         // Todo: use mock provider instead?
         let mut server =
-            MockTransport::bind::<Provider>(notifier.waiter(), MockTransportConfig { port: 420 })
-                .await?;
+            MockTransport::bind(notifier.waiter(), MockTransportConfig { port: 420 }).await?;
 
         let client = dial_mock(420).await.unwrap();
         // send the initial handshake
@@ -190,6 +188,8 @@ mod tests {
                 schema::HandshakeRequestFrame::Handshake {
                     retry: None,
                     service: 0,
+                    expiry: 0,
+                    nonce: 0,
                     pk: ClientPublicKey([1; 96]),
                     pop: ClientSignature([2; 48]),
                 }

--- a/core/handshake/src/transports/webrtc/mod.rs
+++ b/core/handshake/src/transports/webrtc/mod.rs
@@ -57,10 +57,7 @@ impl Transport for WebRtcTransport {
     type Sender = WebRtcSender;
     type Receiver = WebRtcReceiver;
 
-    async fn bind<P: ExecutorProviderInterface>(
-        waiter: ShutdownWaiter,
-        config: Self::Config,
-    ) -> Result<(Self, Option<Router>)> {
+    async fn bind(waiter: ShutdownWaiter, config: Self::Config) -> Result<(Self, Option<Router>)> {
         info!("Binding WebRTC transport on {}", config.address);
         let conns = Arc::new(DashMap::new());
 

--- a/core/handshake/src/transports/webtransport/mod.rs
+++ b/core/handshake/src/transports/webtransport/mod.rs
@@ -38,7 +38,7 @@ impl Transport for WebTransport {
     type Sender = WebTransportSender;
     type Receiver = WebTransportReceiver;
 
-    async fn bind<P: ExecutorProviderInterface>(
+    async fn bind(
         shutdown: ShutdownWaiter,
         config: Self::Config,
     ) -> anyhow::Result<(Self, Option<Router>)> {

--- a/core/schema/Cargo.toml
+++ b/core/schema/Cargo.toml
@@ -3,8 +3,6 @@ name = "lightning-schema"
 version = "0.0.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 serde.workspace = true
 anyhow.workspace = true
@@ -15,3 +13,4 @@ bytes = "1.5"
 arrayref = "0.3"
 flexbuffers = "2.0"
 lightning-workspace-hack.workspace = true
+sha2 = "0.10.8"

--- a/core/schema/src/handshake.rs
+++ b/core/schema/src/handshake.rs
@@ -183,7 +183,7 @@ impl HandshakeResponse {
 
     pub fn decode(bytes: &[u8]) -> Result<Self> {
         if bytes.len() != 96 {
-            return Err(anyhow!("wrong number of bytes"));
+            return Err(anyhow!("wrong number of bytes, got {}", bytes.len()));
         }
 
         let pk = NodePublicKey(*array_ref!(bytes, 0, 32));

--- a/lib/cdk-rust/src/connection.rs
+++ b/lib/cdk-rust/src/connection.rs
@@ -33,6 +33,9 @@ async fn start_handshake<T: Transport>(
     let frame = HandshakeRequestFrame::Handshake {
         retry: None,
         service: setting.service_id,
+        // TODO
+        expiry: 0,
+        nonce: 0,
         pk,
         // Todo: Create signature.
         pop: ClientSignature([0; 48]),

--- a/services/fetcher/Cargo.toml
+++ b/services/fetcher/Cargo.toml
@@ -18,6 +18,7 @@ lightning-workspace-hack.workspace = true
 
 [dev-dependencies]
 lightning-schema = { path = "../../core/schema" }
+fleek-crypto = { path = "../../lib/fleek-crypto" }
 
 [[bin]]
 name = "fn-service-0"

--- a/services/fetcher/examples/fetcher-client.rs
+++ b/services/fetcher/examples/fetcher-client.rs
@@ -1,3 +1,5 @@
+use std::time::SystemTime;
+
 use arrayref::array_ref;
 use bytes::{BufMut, BytesMut};
 use cid::Cid;
@@ -20,6 +22,12 @@ async fn main() -> anyhow::Result<()> {
         .send_handshake(HandshakeRequestFrame::Handshake {
             retry: None,
             service: SERVICE_ID,
+            expiry: SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_secs()
+                + 30,
+            nonce: 0, // TODO
             pk: [0; 96].into(),
             pop: [0; 48].into(),
         })

--- a/services/fetcher/examples/fetcher-client.rs
+++ b/services/fetcher/examples/fetcher-client.rs
@@ -3,8 +3,14 @@ use std::time::SystemTime;
 use arrayref::array_ref;
 use bytes::{BufMut, BytesMut};
 use cid::Cid;
+use fleek_crypto::{ClientSecretKey, SecretKey};
 use fleek_service_fetcher::Origin;
-use lightning_schema::handshake::{HandshakeRequestFrame, RequestFrame, ResponseFrame};
+use lightning_schema::handshake::{
+    handshake_digest,
+    HandshakeRequestFrame,
+    RequestFrame,
+    ResponseFrame,
+};
 use tcp_client::TcpClient;
 
 const ADDRESS: &str = "127.0.0.1:4221";
@@ -12,26 +18,37 @@ const SERVICE_ID: u32 = 0;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let (origin, uid) = cli::args();
+    let (origin, uid, verify) = cli::args();
 
-    println!("Sending handshake");
-
-    // Connect and handshake with the node
     let mut client = TcpClient::connect(ADDRESS).await?;
-    client
-        .send_handshake(HandshakeRequestFrame::Handshake {
-            retry: None,
-            service: SERVICE_ID,
-            expiry: SystemTime::now()
-                .duration_since(SystemTime::UNIX_EPOCH)
-                .unwrap()
-                .as_secs()
-                + 30,
-            nonce: 0, // TODO
-            pk: [0; 96].into(),
-            pop: [0; 48].into(),
-        })
-        .await?;
+
+    if verify {
+        println!("sending handshake");
+
+        // TODO(oz): use a real client key assigned to an eth account
+        let sk = ClientSecretKey::generate();
+
+        let expiry = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            + 30;
+        let nonce = 1; // todo
+        let pk = sk.to_pk();
+        let digest = handshake_digest(None, SERVICE_ID, expiry, nonce, pk);
+        let pop = sk.sign(&digest);
+
+        client
+            .send_handshake(HandshakeRequestFrame::Handshake {
+                retry: None,
+                service: SERVICE_ID,
+                expiry,
+                nonce,
+                pk,
+                pop,
+            })
+            .await?;
+    }
 
     println!("Sending content request for {uid}");
 
@@ -83,7 +100,7 @@ async fn main() -> anyhow::Result<()> {
 mod cli {
     use fleek_service_fetcher::Origin;
 
-    pub fn args() -> (Origin, String) {
+    pub fn args() -> (Origin, String, bool) {
         let mut args = std::env::args();
         args.next();
 
@@ -104,17 +121,17 @@ mod cli {
             }
         };
 
-        (origin, uid)
+        (origin, uid, args.any(|v| v == "--pop"))
     }
 
     fn help() {
         println!(
-            "Usage: ./cdn-client <UID> [ipfs|blake3, default: ipfs]
+            "Usage: ./cdn-client <UID> [ipfs|blake3, default: ipfs] [--pop]
 
-Examples: 
+Examples:
     Big Buck Bunny:
         ./cdn-client b4bb88454076fa65e9c6f7f4343b02ccea7fbd9a6b9235d177fe71cfdc5d7043 blake3
-        ./cdn-client bafybeibi5vlbuz3jstustlxbxk7tmxsyjjrxak6us4yqq6z2df3jwidiwi ipfs 
+        ./cdn-client bafybeibi5vlbuz3jstustlxbxk7tmxsyjjrxak6us4yqq6z2df3jwidiwi ipfs
 
     Puppet Image:
         ./cdn-client 62c6f749c80a27813a84066b92a6fdc37fd83779bf9d64f1f1a3692cf3a7dfbd blake3
@@ -124,10 +141,15 @@ Examples:
 }
 
 mod tcp_client {
-    use anyhow::Result;
+    use anyhow::{Context, Result};
     use arrayref::array_ref;
-    use bytes::{Bytes, BytesMut};
-    use lightning_schema::handshake::{HandshakeRequestFrame, RequestFrame, ResponseFrame};
+    use bytes::{Buf, Bytes, BytesMut};
+    use lightning_schema::handshake::{
+        HandshakeRequestFrame,
+        HandshakeResponse,
+        RequestFrame,
+        ResponseFrame,
+    };
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::{TcpStream, ToSocketAddrs};
 
@@ -137,6 +159,7 @@ mod tcp_client {
     }
 
     impl TcpClient {
+        #[inline(always)]
         pub async fn connect<A: ToSocketAddrs>(addr: A) -> Result<Self> {
             let stream = TcpStream::connect(addr).await?;
             Ok(Self {
@@ -145,7 +168,7 @@ mod tcp_client {
             })
         }
 
-        pub async fn recv(&mut self) -> Option<ResponseFrame> {
+        async fn recv_inner(&mut self) -> Option<BytesMut> {
             loop {
                 if self.buffer.len() < 4 {
                     // Read more bytes for the length delimiter
@@ -161,28 +184,39 @@ mod tcp_client {
                     }
 
                     // take the frame bytes from the buffer
-                    let bytes = self.buffer.split_to(len);
+                    self.buffer.advance(4);
+                    let bytes = self.buffer.split_to(len - 4);
 
-                    // decode the frame
-                    match ResponseFrame::decode(&bytes[4..]) {
-                        Ok(frame) => return Some(frame),
-                        Err(_) => {
-                            eprintln!("invalid frame, dropping payload");
-                            continue;
-                        },
-                    }
+                    return Some(bytes);
                 }
             }
         }
 
-        pub async fn send_handshake(&mut self, frame: HandshakeRequestFrame) -> Result<()> {
-            self.send_inner(frame.encode()).await
+        #[inline(always)]
+        pub async fn recv(&mut self) -> Option<ResponseFrame> {
+            ResponseFrame::decode(&self.recv_inner().await?).ok()
         }
 
+        #[inline(always)]
+        pub async fn send_handshake(
+            &mut self,
+            frame: HandshakeRequestFrame,
+        ) -> Result<HandshakeResponse> {
+            self.send_inner(frame.encode()).await?;
+            HandshakeResponse::decode(
+                &self
+                    .recv_inner()
+                    .await
+                    .context("expected handshake response frame")?,
+            )
+        }
+
+        #[inline(always)]
         pub async fn send(&mut self, frame: RequestFrame) -> Result<()> {
             self.send_inner(frame.encode()).await
         }
 
+        #[inline(always)]
         async fn send_inner(&mut self, bytes: Bytes) -> Result<()> {
             self.stream.write_u32(bytes.len() as u32).await?;
             self.stream.write_all(&bytes).await?;

--- a/services/js-poc/examples/js-poc-client.rs
+++ b/services/js-poc/examples/js-poc-client.rs
@@ -1,3 +1,5 @@
+use std::time::SystemTime;
+
 use anyhow::anyhow;
 use fleek_service_js_poc::stream::Request;
 use lightning_schema::handshake::{HandshakeRequestFrame, RequestFrame, ResponseFrame};
@@ -17,6 +19,14 @@ async fn main() -> anyhow::Result<()> {
         .send_handshake(HandshakeRequestFrame::Handshake {
             retry: None,
             service: SERVICE_ID,
+            // set expiry to 30s from now. We have a runtime cap at 15s, and only plan to run a
+            // single request.
+            expiry: SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_secs()
+                + 30,
+            nonce: 0, // TODO
             pk: [0; 96].into(),
             pop: [0; 48].into(),
         })


### PR DESCRIPTION
Adds pop verification to handshake. Client signs in the hello frame with a nonce to prove possession of the key and authenticate.

- Outlines session expiration in the handshake frame. The pod signatures would include a timestamp that must fall before the expiration.
- added --pop test flag to the fetcher client. Working, but fails later on for the blockstore sdk utils and the new b3fs integration
- added `handshake.verify` config field for enabling the pop verification and sending back the handshake response (can enable when testing, but testnet can still ignore it until we have the full pod flow)