### PR TITLE
rust 1.85 nightly

### DIFF
--- a/core/application/src/config.rs
+++ b/core/application/src/config.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use std::time::SystemTime;
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{anyhow, Context, Result};
 use atomo::{AtomoBuilder, DefaultSerdeBackend};
 use atomo_rocks::{Cache as RocksCache, Env as RocksEnv, Options};
 use lightning_interfaces::types::Genesis;

--- a/core/application/src/config.rs
+++ b/core/application/src/config.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use std::time::SystemTime;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use atomo::{AtomoBuilder, DefaultSerdeBackend};
 use atomo_rocks::{Cache as RocksCache, Env as RocksEnv, Options};
 use lightning_interfaces::types::Genesis;
@@ -80,7 +80,7 @@ impl ApplicationConfig {
     pub fn atomo_builder<'a>(
         &'a self,
         checkpoint: Option<([u8; 32], &'a [u8], &'a [String])>,
-    ) -> Result<AtomoBuilder<AtomoStorageBuilder, DefaultSerdeBackend>> {
+    ) -> Result<AtomoBuilder<AtomoStorageBuilder<'a>, DefaultSerdeBackend>> {
         let storage = match self.storage {
             StorageConfig::RocksDb => {
                 let db_path = self

--- a/core/application/src/state/context.rs
+++ b/core/application/src/state/context.rs
@@ -4,8 +4,8 @@ use std::hash::Hash;
 
 use atomo::{KeyIterator, SerdeBackend, StorageBackend, TableRef as AtomoTableRef, TableSelector};
 use fxhash::FxHashMap;
-use serde::de::DeserializeOwned;
 use serde::Serialize;
+use serde::de::DeserializeOwned;
 
 pub trait Backend {
     type Ref<K: Eq + Hash + Send + Serialize + DeserializeOwned
@@ -59,12 +59,11 @@ pub struct AtomoTable<
 >(RefCell<AtomoTableRef<'selector, K, V, B, S>>);
 
 impl<
-    'selector,
     K: Hash + Eq + Serialize + DeserializeOwned + Any,
     V: Serialize + DeserializeOwned + Any + Clone,
     B: StorageBackend,
     S: SerdeBackend,
-> TableRef<K, V> for AtomoTable<'selector, K, V, B, S>
+> TableRef<K, V> for AtomoTable<'_, K, V, B, S>
 {
     fn set(&self, key: K, value: V) {
         self.0.borrow_mut().insert(key, value);

--- a/core/application/src/state/context.rs
+++ b/core/application/src/state/context.rs
@@ -4,8 +4,8 @@ use std::hash::Hash;
 
 use atomo::{KeyIterator, SerdeBackend, StorageBackend, TableRef as AtomoTableRef, TableSelector};
 use fxhash::FxHashMap;
-use serde::Serialize;
 use serde::de::DeserializeOwned;
+use serde::Serialize;
 
 pub trait Backend {
     type Ref<K: Eq + Hash + Send + Serialize + DeserializeOwned
@@ -59,11 +59,11 @@ pub struct AtomoTable<
 >(RefCell<AtomoTableRef<'selector, K, V, B, S>>);
 
 impl<
-    K: Hash + Eq + Serialize + DeserializeOwned + Any,
-    V: Serialize + DeserializeOwned + Any + Clone,
-    B: StorageBackend,
-    S: SerdeBackend,
-> TableRef<K, V> for AtomoTable<'_, K, V, B, S>
+        K: Hash + Eq + Serialize + DeserializeOwned + Any,
+        V: Serialize + DeserializeOwned + Any + Clone,
+        B: StorageBackend,
+        S: SerdeBackend,
+    > TableRef<K, V> for AtomoTable<'_, K, V, B, S>
 {
     fn set(&self, key: K, value: V) {
         self.0.borrow_mut().insert(key, value);

--- a/core/application/src/state/executor.rs
+++ b/core/application/src/state/executor.rs
@@ -5,7 +5,7 @@ use std::ops::DerefMut;
 use std::time::Duration;
 
 use ethers::abi::AbiDecode;
-use ethers::types::{H160, Transaction as EthersTransaction};
+use ethers::types::{Transaction as EthersTransaction, H160};
 use fleek_crypto::{
     ClientPublicKey,
     ConsensusPublicKey,
@@ -15,7 +15,6 @@ use fleek_crypto::{
 };
 use hp_fixed::unsigned::HpUfixed;
 use lazy_static::lazy_static;
-use lightning_interfaces::ToDigest;
 use lightning_interfaces::types::{
     AccountInfo,
     Blake3Hash,
@@ -28,9 +27,6 @@ use lightning_interfaces::types::{
     Epoch,
     ExecutionData,
     ExecutionError,
-    MAX_MEASUREMENTS_PER_TX,
-    MAX_MEASUREMENTS_SUBMIT,
-    MAX_UPDATES_CONTENT_REGISTRY,
     Metadata,
     MintInfo,
     NodeIndex,
@@ -59,7 +55,11 @@ use lightning_interfaces::types::{
     UpdateRequest,
     Value,
     WithdrawInfo,
+    MAX_MEASUREMENTS_PER_TX,
+    MAX_MEASUREMENTS_SUBMIT,
+    MAX_UPDATES_CONTENT_REGISTRY,
 };
+use lightning_interfaces::ToDigest;
 use lightning_utils::eth::fleek_contract::FleekContractCalls;
 use lightning_utils::eth::{
     ApproveClientKeyCall,
@@ -522,12 +522,15 @@ impl<B: Backend> StateExecutor<B> {
                     return TransactionResponse::Revert(ExecutionError::InsufficientBalance);
                 }
                 account.flk_balance -= amount.clone();
-                self.withdraws.set(withdraw_id, WithdrawInfo {
-                    epoch: 0,
-                    token: Tokens::FLK,
-                    receiver,
-                    amount,
-                });
+                self.withdraws.set(
+                    withdraw_id,
+                    WithdrawInfo {
+                        epoch: 0,
+                        token: Tokens::FLK,
+                        receiver,
+                        amount,
+                    },
+                );
                 self.metadata
                     .set(Metadata::WithdrawId, Value::WithdrawId(withdraw_id + 1));
             },
@@ -538,12 +541,15 @@ impl<B: Backend> StateExecutor<B> {
                     return TransactionResponse::Revert(ExecutionError::InsufficientBalance);
                 }
                 account.stables_balance -= amount.clone();
-                self.withdraws.set(withdraw_id, WithdrawInfo {
-                    epoch: 0,
-                    token: Tokens::USDC,
-                    receiver,
-                    amount: amount.convert_precision::<18>(),
-                });
+                self.withdraws.set(
+                    withdraw_id,
+                    WithdrawInfo {
+                        epoch: 0,
+                        token: Tokens::USDC,
+                        receiver,
+                        amount: amount.convert_precision::<18>(),
+                    },
+                );
                 self.metadata
                     .set(Metadata::WithdrawId, Value::WithdrawId(withdraw_id + 1));
             },

--- a/core/application/src/storage.rs
+++ b/core/application/src/storage.rs
@@ -71,7 +71,7 @@ impl<'a> AtomoStorageBuilder<'a> {
     }
 }
 
-impl<'a> StorageBackendConstructor for AtomoStorageBuilder<'a> {
+impl StorageBackendConstructor for AtomoStorageBuilder<'_> {
     type Storage = AtomoStorage;
 
     type Error = anyhow::Error;

--- a/core/application/src/tests/committee_beacon.rs
+++ b/core/application/src/tests/committee_beacon.rs
@@ -1991,9 +1991,9 @@ async fn test_committee_beacon_node_can_reveal_after_committing_and_becoming_ina
 
     // Execute opt-out transaction from 1 of the nodes.
     let resp = network
-        .execute(vec![
-            network.node(0).build_transaction(UpdateMethod::OptOut {}),
-        ])
+        .execute(vec![network
+            .node(0)
+            .build_transaction(UpdateMethod::OptOut {})])
         .await
         .unwrap();
     assert_eq!(resp.block_number, 3);
@@ -2475,9 +2475,9 @@ async fn test_committee_beacon_non_committee_node_participation() {
     // Note that we remove the non-participating committee node, otherwise the reveal transaction
     // from the removed node would be rejected.
     let resp = network
-        .execute(vec![
-            network.node(3).build_transaction(UpdateMethod::OptOut {}),
-        ])
+        .execute(vec![network
+            .node(3)
+            .build_transaction(UpdateMethod::OptOut {})])
         .await
         .unwrap();
     assert_eq!(resp.block_number, 5);

--- a/core/application/src/tests/epoch_change.rs
+++ b/core/application/src/tests/epoch_change.rs
@@ -148,12 +148,11 @@ async fn test_epoch_change_with_all_committee_nodes() {
 
     // Check that the ready-to-change set for the next epoch is empty.
     for node in network.nodes() {
-        assert!(
-            node.app_query()
-                .get_committee_info(&(epoch + 1), |c| c.ready_to_change)
-                .unwrap_or_default()
-                .is_empty()
-        );
+        assert!(node
+            .app_query()
+            .get_committee_info(&(epoch + 1), |c| c.ready_to_change)
+            .unwrap_or_default()
+            .is_empty());
     }
 
     // Shutdown the network.
@@ -318,12 +317,11 @@ async fn test_epoch_change_with_some_non_committee_nodes() {
 
     // Check that the ready-to-change set for the next epoch is empty.
     for node in network.nodes() {
-        assert!(
-            node.app_query()
-                .get_committee_info(&(epoch + 1), |c| c.ready_to_change)
-                .unwrap_or_default()
-                .is_empty()
-        );
+        assert!(node
+            .app_query()
+            .get_committee_info(&(epoch + 1), |c| c.ready_to_change)
+            .unwrap_or_default()
+            .is_empty());
     }
 
     // Shutdown the network.
@@ -353,11 +351,9 @@ async fn test_change_epoch_with_only_locked_stake() {
 
     // Execute epoch change transaction from the node with only locked stake.
     let resp = network
-        .execute(vec![
-            network
-                .node(0)
-                .build_transaction(UpdateMethod::ChangeEpoch { epoch }),
-        ])
+        .execute(vec![network
+            .node(0)
+            .build_transaction(UpdateMethod::ChangeEpoch { epoch })])
         .await
         .unwrap();
     assert_eq!(resp.block_number, 1);
@@ -365,11 +361,9 @@ async fn test_change_epoch_with_only_locked_stake() {
 
     // Execute epoch change transaction from the node with unlocked stake.
     let resp = network
-        .execute(vec![
-            network
-                .node(1)
-                .build_transaction(UpdateMethod::ChangeEpoch { epoch }),
-        ])
+        .execute(vec![network
+            .node(1)
+            .build_transaction(UpdateMethod::ChangeEpoch { epoch })])
         .await
         .unwrap();
     assert_eq!(resp.block_number, 2);
@@ -395,20 +389,18 @@ async fn test_change_epoch_reverts_if_node_opted_out() {
 
     // Execute opt-out transaction from the first node.
     let resp = network
-        .execute(vec![
-            network.node(0).build_transaction(UpdateMethod::OptOut {}),
-        ])
+        .execute(vec![network
+            .node(0)
+            .build_transaction(UpdateMethod::OptOut {})])
         .await
         .unwrap();
     assert_eq!(resp.block_number, 1);
 
     // Execute epoch change transaction from the node and check that it reverts.
     let resp = network
-        .maybe_execute(vec![
-            network
-                .node(0)
-                .build_transaction(UpdateMethod::ChangeEpoch { epoch }),
-        ])
+        .maybe_execute(vec![network
+            .node(0)
+            .build_transaction(UpdateMethod::ChangeEpoch { epoch })])
         .await
         .unwrap();
     assert_eq!(resp.block_number, 2);

--- a/core/application/src/tests/participation.rs
+++ b/core/application/src/tests/participation.rs
@@ -64,20 +64,16 @@ async fn test_uptime_participation() {
     )
     .await
     .unwrap();
-    assert!(
-        !node
-            .app_query()
-            .get_content_registry(&peer1.index())
-            .unwrap_or_default()
-            .is_empty()
-    );
-    assert!(
-        !node
-            .app_query()
-            .get_content_registry(&peer2.index())
-            .unwrap_or_default()
-            .is_empty()
-    );
+    assert!(!node
+        .app_query()
+        .get_content_registry(&peer1.index())
+        .unwrap_or_default()
+        .is_empty());
+    assert!(!node
+        .app_query()
+        .get_content_registry(&peer2.index())
+        .unwrap_or_default()
+        .is_empty());
 
     // Submit reputation measurements from node 0, for peer 1 and 2.
     let measurements: BTreeMap<u32, lightning_interfaces::types::ReputationMeasurements> =

--- a/core/application/src/tests/reputation.rs
+++ b/core/application/src/tests/reputation.rs
@@ -152,16 +152,14 @@ async fn test_rep_scores() {
     network.change_epoch_and_wait_for_complete().await.unwrap();
 
     // Check the reputation scores.
-    assert!(
-        node.app_query()
-            .get_reputation_score(&peer1.index())
-            .is_some()
-    );
-    assert!(
-        node.app_query()
-            .get_reputation_score(&peer2.index())
-            .is_some()
-    );
+    assert!(node
+        .app_query()
+        .get_reputation_score(&peer1.index())
+        .is_some());
+    assert!(node
+        .app_query()
+        .get_reputation_score(&peer2.index())
+        .is_some());
 
     // Shutdown the network.
     network.shutdown().await;

--- a/core/application/src/tests/staking.rs
+++ b/core/application/src/tests/staking.rs
@@ -74,13 +74,11 @@ async fn test_stake() {
         .unwrap();
     assert_eq!(node_registry_changes.len(), 1);
     assert_eq!(node_registry_changes.get(&0).unwrap().len(), committee_size);
-    assert!(
-        node_registry_changes
-            .get(&0)
-            .unwrap()
-            .iter()
-            .all(|(_, change)| { matches!(change, NodeRegistryChange::New) })
-    );
+    assert!(node_registry_changes
+        .get(&0)
+        .unwrap()
+        .iter()
+        .all(|(_, change)| { matches!(change, NodeRegistryChange::New) }));
 
     let owner_secret_key = AccountOwnerSecretKey::generate();
     let peer_pub_key = NodeSecretKey::generate().to_pk();

--- a/core/blockstore-server/src/blockstore_server.rs
+++ b/core/blockstore-server/src/blockstore_server.rs
@@ -5,12 +5,12 @@ use std::borrow::Cow;
 use std::collections::{HashMap, VecDeque};
 use std::mem;
 use std::net::SocketAddr;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use affair::{Socket, Task};
-use anyhow::{Result, anyhow};
+use anyhow::{anyhow, Result};
 use b3fs::entry::{BorrowedEntry, InlineVec, OwnedEntry, OwnedLink};
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use lightning_interfaces::prelude::*;
@@ -30,7 +30,7 @@ use lightning_interfaces::{
 };
 use lightning_metrics::increment_counter;
 use serde::{Deserialize, Serialize};
-use tokio::sync::{RwLock, broadcast, mpsc};
+use tokio::sync::{broadcast, mpsc, RwLock};
 use tokio::task::JoinSet;
 use tokio::time::timeout;
 use tokio_stream::StreamExt;

--- a/core/blockstore-server/src/blockstore_server.rs
+++ b/core/blockstore-server/src/blockstore_server.rs
@@ -5,12 +5,12 @@ use std::borrow::Cow;
 use std::collections::{HashMap, VecDeque};
 use std::mem;
 use std::net::SocketAddr;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
 use affair::{Socket, Task};
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use b3fs::entry::{BorrowedEntry, InlineVec, OwnedEntry, OwnedLink};
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use lightning_interfaces::prelude::*;
@@ -30,7 +30,7 @@ use lightning_interfaces::{
 };
 use lightning_metrics::increment_counter;
 use serde::{Deserialize, Serialize};
-use tokio::sync::{broadcast, mpsc, RwLock};
+use tokio::sync::{RwLock, broadcast, mpsc};
 use tokio::task::JoinSet;
 use tokio::time::timeout;
 use tokio_stream::StreamExt;
@@ -326,7 +326,7 @@ pub enum DirFrame<'a> {
     Eos,
 }
 
-impl<'a> DirFrame<'a> {
+impl DirFrame<'_> {
     fn entry_len(entry: &OwnedEntry) -> usize {
         let mut bytes = entry.name.len();
         match &entry.link {
@@ -355,7 +355,7 @@ impl<'a> DirFrame<'a> {
     }
 }
 
-impl<'a> From<Frame<'a>> for Bytes {
+impl From<Frame<'_>> for Bytes {
     fn from(value: Frame) -> Self {
         let mut b = BytesMut::new();
         match value {

--- a/core/checkpointer/src/tests.rs
+++ b/core/checkpointer/src/tests.rs
@@ -93,15 +93,13 @@ async fn test_supermajority_over_epoch_changes() {
         .unwrap();
         for (node_id, agg_header) in agg_header_by_node.iter() {
             // Verify the aggregate header signature.
-            assert!(
-                verify_aggregate_checkpointer_header(
-                    &network,
-                    agg_header.clone(),
-                    *node_id,
-                    headers_by_node.clone(),
-                )
-                .unwrap()
-            );
+            assert!(verify_aggregate_checkpointer_header(
+                &network,
+                agg_header.clone(),
+                *node_id,
+                headers_by_node.clone(),
+            )
+            .unwrap());
 
             // Check that the aggregate header is correct.
             assert_eq!(
@@ -308,15 +306,13 @@ async fn test_missing_epoch_change_notification_still_supermajority() {
     .unwrap();
     for (node_id, agg_header) in agg_header_by_node.iter() {
         // Verify the aggregate header signature.
-        assert!(
-            verify_aggregate_checkpointer_header(
-                &network,
-                agg_header.clone(),
-                *node_id,
-                headers_by_node.clone(),
-            )
-            .unwrap()
-        );
+        assert!(verify_aggregate_checkpointer_header(
+            &network,
+            agg_header.clone(),
+            *node_id,
+            headers_by_node.clone(),
+        )
+        .unwrap());
 
         // Check that the aggregate header is correct.
         assert_eq!(
@@ -450,15 +446,13 @@ async fn test_delayed_epoch_change_notification() {
     .unwrap();
     assert_eq!(agg_header_by_node.len(), 3);
     for (node_id, agg_header) in agg_header_by_node.iter() {
-        assert!(
-            verify_aggregate_checkpointer_header(
-                &network,
-                agg_header.clone(),
-                *node_id,
-                headers_by_node.clone(),
-            )
-            .unwrap()
-        );
+        assert!(verify_aggregate_checkpointer_header(
+            &network,
+            agg_header.clone(),
+            *node_id,
+            headers_by_node.clone(),
+        )
+        .unwrap());
         assert_eq!(
             agg_header,
             &AggregateCheckpoint {
@@ -583,15 +577,13 @@ async fn test_multiple_different_epoch_change_notifications_simultaneously() {
     .unwrap();
     for (node_id, agg_header) in agg_header_by_node.iter() {
         // Verify the aggregate header signature.
-        assert!(
-            verify_aggregate_checkpointer_header(
-                &network,
-                agg_header.clone(),
-                *node_id,
-                epoch1_headers_by_node.clone(),
-            )
-            .unwrap()
-        );
+        assert!(verify_aggregate_checkpointer_header(
+            &network,
+            agg_header.clone(),
+            *node_id,
+            epoch1_headers_by_node.clone(),
+        )
+        .unwrap());
 
         // Check that the aggregate header is correct.
         assert_eq!(
@@ -612,15 +604,13 @@ async fn test_multiple_different_epoch_change_notifications_simultaneously() {
     .unwrap();
     for (node_id, agg_header) in agg_header_by_node.iter() {
         // Verify the aggregate header signature.
-        assert!(
-            verify_aggregate_checkpointer_header(
-                &network,
-                agg_header.clone(),
-                *node_id,
-                epoch2_headers_by_node.clone(),
-            )
-            .unwrap()
-        );
+        assert!(verify_aggregate_checkpointer_header(
+            &network,
+            agg_header.clone(),
+            *node_id,
+            epoch2_headers_by_node.clone(),
+        )
+        .unwrap());
 
         // Check that the aggregate header is correct.
         assert_eq!(
@@ -831,15 +821,13 @@ async fn test_attestations_with_inconsistent_state_roots_still_supermajority() {
 
     for (node_id, agg_header) in agg_header_by_node.iter() {
         // Verify the aggregate header signature.
-        assert!(
-            verify_aggregate_checkpointer_header(
-                &network,
-                agg_header.clone(),
-                *node_id,
-                headers_by_node.clone(),
-            )
-            .unwrap()
-        );
+        assert!(verify_aggregate_checkpointer_header(
+            &network,
+            agg_header.clone(),
+            *node_id,
+            headers_by_node.clone(),
+        )
+        .unwrap());
 
         // Check that the aggregate header is correct.
         assert_eq!(

--- a/core/cli/src/commands/dev.rs
+++ b/core/cli/src/commands/dev.rs
@@ -131,7 +131,7 @@ async fn fetch<C: NodeComponents<ConfigProviderInterface = TomlConfigProvider<C>
 
 struct ByteBuf<'a>(&'a [u8]);
 
-impl<'a> std::fmt::LowerHex for ByteBuf<'a> {
+impl std::fmt::LowerHex for ByteBuf<'_> {
     fn fmt(&self, fmtr: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
         for byte in self.0 {
             fmtr.write_fmt(format_args!("{:02x}", byte))?;

--- a/core/cli/src/commands/opt.rs
+++ b/core/cli/src/commands/opt.rs
@@ -247,7 +247,7 @@ pub async fn query_node_info(
         return Err(anyhow!("Failed to get node info from bootstrap nodes"));
     }
     node_info.sort_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap());
-    Ok(node_info.pop().unwrap().0.0)
+    Ok(node_info.pop().unwrap().0 .0)
 }
 
 pub async fn query_epoch_info(nodes: &[NodeInfo]) -> Result<EpochInfo> {

--- a/core/cli/tests/init.rs
+++ b/core/cli/tests/init.rs
@@ -70,7 +70,7 @@ mod init_tests {
             "Node configuration file written to {}",
             config_path.to_string_lossy()
         )));
-        assert!(config_path.exists() && fs::metadata(&config_path).map_or(false, |m| m.len() > 0));
+        assert!(config_path.exists() && fs::metadata(&config_path).is_ok_and(|m| m.len() > 0));
         let config = fs::read_to_string(&config_path).unwrap();
         assert!(!config.contains("[application.dev]"));
         assert!(!config.contains("update_epoch_start_to_now = true"));
@@ -124,7 +124,7 @@ mod init_tests {
             "Node configuration file written to {}",
             config_path.to_string_lossy()
         )));
-        assert!(config_path.exists() && fs::metadata(config_path).map_or(false, |m| m.len() > 0));
+        assert!(config_path.exists() && fs::metadata(config_path).is_ok_and(|m| m.len() > 0));
 
         let genesis_path = temp_dir.path().join("genesis.toml");
         assert!(!str::from_utf8(&output.stdout).unwrap().contains(&format!(

--- a/core/cli/tests/init.rs
+++ b/core/cli/tests/init.rs
@@ -82,16 +82,12 @@ mod init_tests {
         )));
         assert!(!genesis_path.exists());
 
-        assert!(
-            str::from_utf8(&output.stdout)
-                .unwrap()
-                .contains("Generated node key:")
-        );
-        assert!(
-            str::from_utf8(&output.stdout)
-                .unwrap()
-                .contains("Generated consensus key:")
-        );
+        assert!(str::from_utf8(&output.stdout)
+            .unwrap()
+            .contains("Generated node key:"));
+        assert!(str::from_utf8(&output.stdout)
+            .unwrap()
+            .contains("Generated consensus key:"));
     }
 
     #[test]
@@ -133,16 +129,12 @@ mod init_tests {
         )));
         assert!(!genesis_path.exists());
 
-        assert!(
-            !str::from_utf8(&output.stdout)
-                .unwrap()
-                .contains("Generated node key:")
-        );
-        assert!(
-            !str::from_utf8(&output.stdout)
-                .unwrap()
-                .contains("Generated consensus key:")
-        );
+        assert!(!str::from_utf8(&output.stdout)
+            .unwrap()
+            .contains("Generated node key:"));
+        assert!(!str::from_utf8(&output.stdout)
+            .unwrap()
+            .contains("Generated consensus key:"));
     }
 
     #[test]
@@ -177,19 +169,14 @@ mod init_tests {
         assert!(config_path.exists());
 
         let genesis_path = temp_dir.path().join("genesis.toml");
-        assert!(
-            str::from_utf8(&output.stdout)
-                .unwrap()
-                .contains(&format!(" written to {}", genesis_path.to_string_lossy()))
-        );
+        assert!(str::from_utf8(&output.stdout)
+            .unwrap()
+            .contains(&format!(" written to {}", genesis_path.to_string_lossy())));
         assert!(genesis_path.exists());
 
         let config = fs::read_to_string(&config_path).unwrap();
-        assert!(
-            config.contains(
-                format!("genesis_path = \"{}\"", genesis_path.to_string_lossy()).as_str()
-            )
-        );
+        assert!(config
+            .contains(format!("genesis_path = \"{}\"", genesis_path.to_string_lossy()).as_str()));
         assert!(config.contains("[application.dev]"));
         assert!(config.contains("update_epoch_start_to_now = true"));
     }
@@ -208,11 +195,9 @@ mod init_tests {
 
         assert!(!output.status.success());
 
-        assert!(
-            str::from_utf8(&output.stderr)
-                .unwrap()
-                .contains("Cannot specify both --dev and --network")
-        );
+        assert!(str::from_utf8(&output.stderr)
+            .unwrap()
+            .contains("Cannot specify both --dev and --network"));
 
         let config_path = temp_dir.path().join("config.toml");
         assert!(!str::from_utf8(&output.stdout).unwrap().contains(&format!(

--- a/core/committee-beacon/tests/tests.rs
+++ b/core/committee-beacon/tests/tests.rs
@@ -142,11 +142,10 @@ async fn test_epoch_change_multiple_nodes() {
 
     // Check that the app state beacons are cleared.
     for node in network.nodes() {
-        assert!(
-            node.app_query()
-                .get_committee_selection_beacons()
-                .is_empty()
-        );
+        assert!(node
+            .app_query()
+            .get_committee_selection_beacons()
+            .is_empty());
     }
 
     // Change epoch and check that the local database beacons are eventually cleared.
@@ -1009,11 +1008,10 @@ async fn test_node_attempts_reveal_without_committment() {
 
     // Check that the app state beacons are cleared.
     for node in network.nodes() {
-        assert!(
-            node.app_query()
-                .get_committee_selection_beacons()
-                .is_empty()
-        );
+        assert!(node
+            .app_query()
+            .get_committee_selection_beacons()
+            .is_empty());
     }
 
     // Shutdown the nodes.

--- a/core/firewall/src/rate_limiting.rs
+++ b/core/firewall/src/rate_limiting.rs
@@ -103,7 +103,7 @@ impl RateLimiting {
                 *global = rules;
 
                 // remove all old global rules
-                per.retain(|_, v| v.first().map_or(false, |f| !f.is_global));
+                per.retain(|_, v| v.first().is_some_and(|f| !f.is_global));
             },
         }
 
@@ -132,7 +132,7 @@ impl RateLimiting {
                             .into_iter()
                             .filter_map(|(k, v)| {
                                 // take the user rules if theyre are not global
-                                if v.first().map_or(false, |policy| !policy.is_global) {
+                                if v.first().is_some_and(|policy| !policy.is_global) {
                                     return Some((k, v.into_iter().map(IsGlobal::inner).collect()));
                                 }
 

--- a/core/firewall/src/service.rs
+++ b/core/firewall/src/service.rs
@@ -1,7 +1,7 @@
 use std::convert::Infallible;
 use std::future::Future;
 use std::pin::Pin;
-use std::task::{Poll, ready};
+use std::task::{ready, Poll};
 
 use tower::Service;
 

--- a/core/firewall/src/service.rs
+++ b/core/firewall/src/service.rs
@@ -1,7 +1,7 @@
 use std::convert::Infallible;
 use std::future::Future;
 use std::pin::Pin;
-use std::task::{ready, Poll};
+use std::task::{Poll, ready};
 
 use tower::Service;
 
@@ -145,7 +145,7 @@ pub trait IntoIpAddr {
     fn ip_addr(&self) -> std::net::IpAddr;
 }
 
-impl<'a> IntoIpAddr for &'a hyper::server::conn::AddrStream {
+impl IntoIpAddr for &hyper::server::conn::AddrStream {
     fn ip_addr(&self) -> std::net::IpAddr {
         self.remote_addr().ip()
     }

--- a/core/interfaces/src/application.rs
+++ b/core/interfaces/src/application.rs
@@ -137,7 +137,7 @@ pub trait SyncQueryRunnerInterface: Clone + Send + Sync + 'static {
     /// Query Node Table
     /// Returns information about a single node.
     fn get_node_info<V>(&self, node: &NodeIndex, selector: impl FnOnce(NodeInfo) -> V)
-    -> Option<V>;
+        -> Option<V>;
 
     /// Returns an Iterator to Node Table
     fn get_node_table_iter<V>(&self, closure: impl FnOnce(KeyIterator<NodeIndex>) -> V) -> V;

--- a/core/pool/src/http.rs
+++ b/core/pool/src/http.rs
@@ -31,7 +31,6 @@ pub async fn spawn_http_server(
         .with_graceful_shutdown(shutdown)
         .await
         .context("failed to run http server")
-        .map(Into::into)
 }
 
 async fn state(

--- a/core/pool/src/muxer/mod.rs
+++ b/core/pool/src/muxer/mod.rs
@@ -92,7 +92,7 @@ where
         // Sends this is a wrapper for a Stream, the error is consumed.
         Pin::new(&mut self.rx)
             .poll_next(cx)
-            .map(|bytes| bytes.map(|b| b.map(Bytes::from).map_err(Into::into)))
+            .map(|bytes| bytes.map(|b| b.map(Bytes::from)))
     }
 }
 

--- a/core/pool/src/tests.rs
+++ b/core/pool/src/tests.rs
@@ -362,14 +362,12 @@ async fn test_send_to_all() {
     }
 
     // Then: the unknown node does not receive the message.
-    assert!(
-        tokio::time::timeout(
-            Duration::from_secs(5),
-            event_handlers_unknown_peer.receive(),
-        )
-        .await
-        .is_err()
-    );
+    assert!(tokio::time::timeout(
+        Duration::from_secs(5),
+        event_handlers_unknown_peer.receive(),
+    )
+    .await
+    .is_err());
 
     // Clean up.
     for mut peer in peers {

--- a/core/reputation/src/statistics.rs
+++ b/core/reputation/src/statistics.rs
@@ -48,7 +48,11 @@ fn abs_difference<T>(a: T, b: T) -> T
 where
     T: Sub<T, Output = T> + PartialOrd<T>,
 {
-    if a > b { a - b } else { b - a }
+    if a > b {
+        a - b
+    } else {
+        b - a
+    }
 }
 
 fn calculate_mean<T>(values: &[T]) -> Option<T>

--- a/core/rpc/src/api/flk.rs
+++ b/core/rpc/src/api/flk.rs
@@ -155,7 +155,7 @@ pub trait FleekApi {
 
     #[method(name = "get_node_registry")]
     async fn get_node_registry(&self, paging: Option<NodePagingParams>)
-    -> RpcResult<Vec<NodeInfo>>;
+        -> RpcResult<Vec<NodeInfo>>;
 
     #[method(name = "get_node_registry_index")]
     async fn get_node_registry_index(

--- a/core/rpc/src/tests.rs
+++ b/core/rpc/src/tests.rs
@@ -676,11 +676,9 @@ async fn test_admin_ping() {
         .downcast::<TestFullNodeComponentsWithMockConsensus>();
 
     // Should fail because we are not authenticated.
-    assert!(
-        AdminApiClient::ping(&node.rpc_client().unwrap())
-            .await
-            .is_err()
-    );
+    assert!(AdminApiClient::ping(&node.rpc_client().unwrap())
+        .await
+        .is_err());
 
     // Should work because we are authenticated.
     let client = node.rpc_admin_client().await.unwrap();

--- a/core/signer/src/tests.rs
+++ b/core/signer/src/tests.rs
@@ -10,9 +10,9 @@ use lightning_notifier::Notifier;
 use lightning_test_utils::consensus::{MockConsensus, MockConsensusConfig, MockForwarder};
 use lightning_test_utils::json_config::JsonConfigProvider;
 use lightning_test_utils::keys::EphemeralKeystore;
-use lightning_utils::poll::{PollUntilError, poll_until};
+use lightning_utils::poll::{poll_until, PollUntilError};
 use lightning_utils::transaction::TransactionSigner;
-use tempfile::{TempDir, tempdir};
+use tempfile::{tempdir, TempDir};
 use types::{
     ExecuteTransactionError,
     ExecuteTransactionOptions,

--- a/core/signer/src/tests.rs
+++ b/core/signer/src/tests.rs
@@ -10,9 +10,9 @@ use lightning_notifier::Notifier;
 use lightning_test_utils::consensus::{MockConsensus, MockConsensusConfig, MockForwarder};
 use lightning_test_utils::json_config::JsonConfigProvider;
 use lightning_test_utils::keys::EphemeralKeystore;
-use lightning_utils::poll::{poll_until, PollUntilError};
+use lightning_utils::poll::{PollUntilError, poll_until};
 use lightning_utils::transaction::TransactionSigner;
-use tempfile::{tempdir, TempDir};
+use tempfile::{TempDir, tempdir};
 use types::{
     ExecuteTransactionError,
     ExecuteTransactionOptions,
@@ -278,6 +278,5 @@ impl<C: NodeComponents> TestNode<C> {
                     }),
             ),
         )
-        .map_err(anyhow::Error::from)
     }
 }

--- a/core/task-broker/src/task_broker.rs
+++ b/core/task-broker/src/task_broker.rs
@@ -8,7 +8,7 @@ use fleek_crypto::{NodePublicKey, NodeSecretKey};
 use futures::stream::FuturesUnordered;
 use futures::{AsyncReadExt, StreamExt, TryStreamExt};
 use lightning_interfaces::prelude::*;
-use lightning_interfaces::{spawn_worker, RequestHeader, RequesterInterface, TaskError};
+use lightning_interfaces::{RequestHeader, RequesterInterface, TaskError, spawn_worker};
 use lightning_metrics::increment_counter;
 use rand::prelude::SliceRandom;
 use rand::thread_rng;
@@ -419,10 +419,9 @@ impl<C: NodeComponents> RequestWorker<C> {
         mut handle: impl lightning_interfaces::RequestInterface,
     ) -> Result<()> {
         // Parse request payload
-        let request = TaskRequest::decode(&header.bytes).map_err(|e| {
+        let request = TaskRequest::decode(&header.bytes).inspect_err(|_| {
             self.rep_reporter
                 .report_unsat(header.peer, lightning_interfaces::Weight::Weak);
-            e
         })?;
 
         let socket = self.socket.clone();

--- a/core/task-broker/src/task_broker.rs
+++ b/core/task-broker/src/task_broker.rs
@@ -8,7 +8,7 @@ use fleek_crypto::{NodePublicKey, NodeSecretKey};
 use futures::stream::FuturesUnordered;
 use futures::{AsyncReadExt, StreamExt, TryStreamExt};
 use lightning_interfaces::prelude::*;
-use lightning_interfaces::{RequestHeader, RequesterInterface, TaskError, spawn_worker};
+use lightning_interfaces::{spawn_worker, RequestHeader, RequesterInterface, TaskError};
 use lightning_metrics::increment_counter;
 use rand::prelude::SliceRandom;
 use rand::thread_rng;

--- a/core/test-utils/src/lsof.rs
+++ b/core/test-utils/src/lsof.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::Path;
 use std::process::Command;
 
-use lightning_utils::poll::{poll_until, PollUntilError};
+use lightning_utils::poll::{PollUntilError, poll_until};
 use minilsof::LsofData;
 use thiserror::Error;
 use tokio::time::Duration;
@@ -28,7 +28,7 @@ pub async fn wait_for_file_to_close(
 
 /// Check if `/proc` is available on the current system.
 fn is_proc_available() -> bool {
-    fs::metadata("/proc").map_or(false, |meta| meta.is_dir())
+    fs::metadata("/proc").is_ok_and(|meta| meta.is_dir())
 }
 
 /// Wait until the given file is no longer open by any process, using the `/proc` filesystem to get

--- a/core/test-utils/src/lsof.rs
+++ b/core/test-utils/src/lsof.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::Path;
 use std::process::Command;
 
-use lightning_utils::poll::{PollUntilError, poll_until};
+use lightning_utils::poll::{poll_until, PollUntilError};
 use minilsof::LsofData;
 use thiserror::Error;
 use tokio::time::Duration;

--- a/core/topology/src/pairing.rs
+++ b/core/topology/src/pairing.rs
@@ -64,7 +64,7 @@ pub fn hueristic_sort(dissim_matrix: &Array2<i32>, a: &mut [usize], b: &[usize])
 
     // 2. reassign indeces
     let len = a.len();
-    let n = (len + b.len() - 1) / b.len(); // ceiling 
+    let n = len.div_ceil(b.len()); // ceiling 
     let mut iter = a.iter_mut();
     for c in 0..n {
         let mut j = c;

--- a/core/topology/src/pairing.rs
+++ b/core/topology/src/pairing.rs
@@ -64,7 +64,7 @@ pub fn hueristic_sort(dissim_matrix: &Array2<i32>, a: &mut [usize], b: &[usize])
 
     // 2. reassign indeces
     let len = a.len();
-    let n = len.div_ceil(b.len()); // ceiling 
+    let n = len.div_ceil(b.len()); // ceiling
     let mut iter = a.iter_mut();
     for c in 0..n {
         let mut j = c;

--- a/core/utils/src/transaction/tests.rs
+++ b/core/utils/src/transaction/tests.rs
@@ -11,7 +11,7 @@ use lightning_test_utils::consensus::{MockConsensus, MockConsensusConfig, MockFo
 use lightning_test_utils::e2e::try_init_tracing;
 use lightning_test_utils::json_config::JsonConfigProvider;
 use lightning_test_utils::keys::EphemeralKeystore;
-use tempfile::{TempDir, tempdir};
+use tempfile::{tempdir, TempDir};
 use types::{
     ExecuteTransactionError,
     ExecuteTransactionOptions,
@@ -30,7 +30,7 @@ use types::{
 };
 
 use super::*;
-use crate::poll::{PollUntilError, poll_until};
+use crate::poll::{poll_until, PollUntilError};
 
 #[tokio::test]
 async fn test_execute_transaction_with_account_signer_wait_for_receipt() {

--- a/core/utils/src/transaction/tests.rs
+++ b/core/utils/src/transaction/tests.rs
@@ -11,7 +11,7 @@ use lightning_test_utils::consensus::{MockConsensus, MockConsensusConfig, MockFo
 use lightning_test_utils::e2e::try_init_tracing;
 use lightning_test_utils::json_config::JsonConfigProvider;
 use lightning_test_utils::keys::EphemeralKeystore;
-use tempfile::{tempdir, TempDir};
+use tempfile::{TempDir, tempdir};
 use types::{
     ExecuteTransactionError,
     ExecuteTransactionOptions,
@@ -30,7 +30,7 @@ use types::{
 };
 
 use super::*;
-use crate::poll::{poll_until, PollUntilError};
+use crate::poll::{PollUntilError, poll_until};
 
 #[tokio::test]
 async fn test_execute_transaction_with_account_signer_wait_for_receipt() {
@@ -650,8 +650,7 @@ impl TestNodeBuilder {
                         },
                     )),
             ),
-        )
-        .map_err(anyhow::Error::from)?;
+        )?;
         Ok(TestNode {
             app: node.provider.get::<C::ApplicationInterface>(),
             notifier: node.provider.get::<C::NotifierInterface>(),

--- a/flake.nix
+++ b/flake.nix
@@ -115,7 +115,7 @@
           craneLib = (crane.mkLib pkgs).overrideToolchain (
             fenix.packages.${system}.fromToolchainFile {
               dir = ./.;
-              sha256 = "X4me+hn5B6fbQGQ7DThreB/DqxexAhEQT8VNvW6Pwq4=";
+              sha256 = "sha256-J0fzDFBqvXT2dqbDdQ71yt2/IKTq4YvQs6QCSkmSdKY=";
             }
           );
 

--- a/lib/atomo-rocks/src/lib.rs
+++ b/lib/atomo-rocks/src/lib.rs
@@ -11,7 +11,7 @@ use atomo::{AtomoBuilder, DefaultSerdeBackend, StorageBackend, StorageBackendCon
 use fxhash::FxHashMap;
 /// Re-export of [`rocksdb::Options`].
 pub use rocksdb::Options;
-pub use rocksdb::{Cache, DB, Env};
+pub use rocksdb::{Cache, Env, DB};
 use rocksdb::{ColumnFamilyDescriptor, WriteBatch};
 pub use serialization::{build_db_from_checkpoint, serialize_db};
 
@@ -365,11 +365,14 @@ mod tests {
                 )
             })
             .collect::<Vec<_>>();
-        assert_eq!(data, vec![
-            (1, "one".to_string()),
-            (2, "two".to_string()),
-            (3, "three".to_string())
-        ]);
+        assert_eq!(
+            data,
+            vec![
+                (1, "one".to_string()),
+                (2, "two".to_string()),
+                (3, "three".to_string())
+            ]
+        );
     }
 
     #[test]

--- a/lib/atomo-rocks/src/lib.rs
+++ b/lib/atomo-rocks/src/lib.rs
@@ -11,7 +11,7 @@ use atomo::{AtomoBuilder, DefaultSerdeBackend, StorageBackend, StorageBackendCon
 use fxhash::FxHashMap;
 /// Re-export of [`rocksdb::Options`].
 pub use rocksdb::Options;
-pub use rocksdb::{Cache, Env, DB};
+pub use rocksdb::{Cache, DB, Env};
 use rocksdb::{ColumnFamilyDescriptor, WriteBatch};
 pub use serialization::{build_db_from_checkpoint, serialize_db};
 
@@ -103,7 +103,7 @@ impl<'a> RocksBackendBuilder<'a> {
     }
 }
 
-impl<'a> StorageBackendConstructor for RocksBackendBuilder<'a> {
+impl StorageBackendConstructor for RocksBackendBuilder<'_> {
     type Storage = RocksBackend;
 
     type Error = anyhow::Error;
@@ -365,14 +365,11 @@ mod tests {
                 )
             })
             .collect::<Vec<_>>();
-        assert_eq!(
-            data,
-            vec![
-                (1, "one".to_string()),
-                (2, "two".to_string()),
-                (3, "three".to_string())
-            ]
-        );
+        assert_eq!(data, vec![
+            (1, "one".to_string()),
+            (2, "two".to_string()),
+            (3, "three".to_string())
+        ]);
     }
 
     #[test]

--- a/lib/atomo/src/table.rs
+++ b/lib/atomo/src/table.rs
@@ -6,8 +6,8 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 use fxhash::{FxHashMap, FxHashSet};
-use serde::de::DeserializeOwned;
 use serde::Serialize;
+use serde::de::DeserializeOwned;
 
 use crate::batch::{BatchReference, Operation, VerticalBatch};
 use crate::db::TableId;
@@ -90,7 +90,7 @@ impl TableMeta {
 }
 
 // When a table ref is dropped make it available to be claimed again.
-impl<'selector, K, V, B: StorageBackend, S: SerdeBackend> Drop for TableRef<'selector, K, V, B, S>
+impl<K, V, B: StorageBackend, S: SerdeBackend> Drop for TableRef<'_, K, V, B, S>
 where
     K: Hash + Eq + Serialize + DeserializeOwned + Any,
     V: Serialize + DeserializeOwned + Any,
@@ -212,7 +212,7 @@ impl<K, V> ResolvedTableReference<K, V> {
     }
 }
 
-impl<'selector, K, V, B: StorageBackend, S: SerdeBackend> TableRef<'selector, K, V, B, S>
+impl<K, V, B: StorageBackend, S: SerdeBackend> TableRef<'_, K, V, B, S>
 where
     K: Hash + Eq + Serialize + DeserializeOwned + Any,
     V: Serialize + DeserializeOwned + Any,

--- a/lib/atomo/src/table.rs
+++ b/lib/atomo/src/table.rs
@@ -6,8 +6,8 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 use fxhash::{FxHashMap, FxHashSet};
-use serde::Serialize;
 use serde::de::DeserializeOwned;
+use serde::Serialize;
 
 use crate::batch::{BatchReference, Operation, VerticalBatch};
 use crate::db::TableId;

--- a/lib/b3fs/src/bucket/dir/phf.rs
+++ b/lib/b3fs/src/bucket/dir/phf.rs
@@ -3,7 +3,7 @@ use std::num::{NonZeroU32, Wrapping};
 
 use rand::distributions::Standard;
 use rand::rngs::SmallRng;
-use rand::{thread_rng, Rng, SeedableRng};
+use rand::{Rng, SeedableRng, thread_rng};
 use siphasher::sip128::{Hash128, Hasher128};
 
 use crate::entry::InlineVec;
@@ -69,7 +69,7 @@ pub fn hash(entry: &[u8], key: u64) -> Hashes {
 const PHF_DEFAULT_LAMBDA: usize = 5;
 
 pub fn calculate_buckets_len(entries_len: usize) -> usize {
-    (entries_len + PHF_DEFAULT_LAMBDA - 1) / PHF_DEFAULT_LAMBDA
+    entries_len.div_ceil(PHF_DEFAULT_LAMBDA)
 }
 
 fn try_generate_hash(entries: &[(InlineVec, Offset)], key: u64) -> Option<HasherState> {

--- a/lib/b3fs/src/bucket/dir/phf.rs
+++ b/lib/b3fs/src/bucket/dir/phf.rs
@@ -3,7 +3,7 @@ use std::num::{NonZeroU32, Wrapping};
 
 use rand::distributions::Standard;
 use rand::rngs::SmallRng;
-use rand::{Rng, SeedableRng, thread_rng};
+use rand::{thread_rng, Rng, SeedableRng};
 use siphasher::sip128::{Hash128, Hasher128};
 
 use crate::entry::InlineVec;

--- a/lib/b3fs/src/bucket/dir/state/mod.rs
+++ b/lib/b3fs/src/bucket/dir/state/mod.rs
@@ -8,10 +8,10 @@ use fastbloom_rs::{BloomFilter, FilterBuilder, Hashes, Membership};
 use tokio::fs::{File, OpenOptions};
 use tokio::io::{self, AsyncWriteExt, BufWriter};
 
+use super::phf::{calculate_buckets_len, HasherState, PhfGenerator};
 use super::HeaderPositions;
-use super::phf::{HasherState, PhfGenerator, calculate_buckets_len};
 use crate::bucket::dir::POSITION_START_HASHES;
-use crate::bucket::{Bucket, HEADER_DIR_VERSION, errors};
+use crate::bucket::{errors, Bucket, HEADER_DIR_VERSION};
 use crate::entry::{BorrowedEntry, BorrowedLink};
 use crate::hasher::dir_hasher::B3_DIR_IS_SYM_LINK;
 use crate::utils::random_file_from;

--- a/lib/b3fs/src/bucket/dir/state/mod.rs
+++ b/lib/b3fs/src/bucket/dir/state/mod.rs
@@ -8,10 +8,10 @@ use fastbloom_rs::{BloomFilter, FilterBuilder, Hashes, Membership};
 use tokio::fs::{File, OpenOptions};
 use tokio::io::{self, AsyncWriteExt, BufWriter};
 
-use super::phf::{calculate_buckets_len, HasherState, PhfGenerator};
 use super::HeaderPositions;
+use super::phf::{HasherState, PhfGenerator, calculate_buckets_len};
 use crate::bucket::dir::POSITION_START_HASHES;
-use crate::bucket::{errors, Bucket, HEADER_DIR_VERSION};
+use crate::bucket::{Bucket, HEADER_DIR_VERSION, errors};
 use crate::entry::{BorrowedEntry, BorrowedLink};
 use crate::hasher::dir_hasher::B3_DIR_IS_SYM_LINK;
 use crate::utils::random_file_from;
@@ -174,9 +174,9 @@ impl HeaderFile {
     /// # Returns
     ///
     /// Returns a Result indicating success or an InsertError.
-    async fn insert_entry<'a>(
+    async fn insert_entry(
         &mut self,
-        borrowed_entry: BorrowedEntry<'a>,
+        borrowed_entry: BorrowedEntry<'_>,
     ) -> Result<usize, errors::InsertError> {
         let (mut flag, content, clen, is_sym) = match borrowed_entry.link {
             crate::entry::BorrowedLink::Content(hash) => (0, hash.as_slice(), 32, false),
@@ -230,9 +230,9 @@ pub trait WithCollector {
 /// Trait defining the operations that can be performed on a directory state.
 pub trait DirState {
     /// Inserts a new entry into the directory.
-    async fn insert_entry<'a>(
+    async fn insert_entry(
         &mut self,
-        borrowed_entry: BorrowedEntry<'a>,
+        borrowed_entry: BorrowedEntry<'_>,
         last_entry: bool,
     ) -> Result<(), errors::InsertError>;
 
@@ -244,9 +244,9 @@ pub trait DirState {
 }
 
 impl<T: WithCollector> DirState for InnerDirState<T> {
-    async fn insert_entry<'b>(
+    async fn insert_entry(
         &mut self,
-        borrowed_entry: BorrowedEntry<'b>,
+        borrowed_entry: BorrowedEntry<'_>,
         last_entry: bool,
     ) -> Result<(), errors::InsertError> {
         let i = self.next_position;

--- a/lib/b3fs/src/collections/flat.rs
+++ b/lib/b3fs/src/collections/flat.rs
@@ -18,7 +18,7 @@ use std::fmt::Debug;
 use std::ops::Index;
 
 use super::error::CollectionTryFromError;
-use crate::utils::{flatten, Digest};
+use crate::utils::{Digest, flatten};
 
 const BYTES_POW_2: usize = 5; // 2 ** 5 == 32
 
@@ -75,7 +75,7 @@ impl<'s> From<&'s Vec<[u8; 32]>> for FlatHashSlice<'s> {
     }
 }
 
-impl<'s> Index<usize> for FlatHashSlice<'s> {
+impl Index<usize> for FlatHashSlice<'_> {
     type Output = [u8; 32];
 
     #[inline]
@@ -94,7 +94,7 @@ impl<'s> IntoIterator for FlatHashSlice<'s> {
     }
 }
 
-impl<'s> AsRef<[u8]> for FlatHashSlice<'s> {
+impl AsRef<[u8]> for FlatHashSlice<'_> {
     #[inline]
     fn as_ref(&self) -> &[u8] {
         self.as_slice()
@@ -204,7 +204,7 @@ impl<'s> Iterator for FlatHashSliceIter<'s> {
     }
 }
 
-impl<'s> DoubleEndedIterator for FlatHashSliceIter<'s> {
+impl DoubleEndedIterator for FlatHashSliceIter<'_> {
     #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
         if self.inner.is_empty() {
@@ -222,7 +222,7 @@ impl<'s> DoubleEndedIterator for FlatHashSliceIter<'s> {
     }
 }
 
-impl<'s> Debug for FlatHashSlice<'s> {
+impl Debug for FlatHashSlice<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut fmt = f.debug_list();
         fmt.entries(self.iter().map(Digest));

--- a/lib/b3fs/src/collections/flat.rs
+++ b/lib/b3fs/src/collections/flat.rs
@@ -18,7 +18,7 @@ use std::fmt::Debug;
 use std::ops::Index;
 
 use super::error::CollectionTryFromError;
-use crate::utils::{Digest, flatten};
+use crate::utils::{flatten, Digest};
 
 const BYTES_POW_2: usize = 5; // 2 ** 5 == 32
 

--- a/lib/b3fs/src/collections/printer.rs
+++ b/lib/b3fs/src/collections/printer.rs
@@ -54,7 +54,7 @@ enum TreeNode<'t> {
     Leaf(&'t [u8; 32]),
 }
 
-impl<'t> Debug for TreeNode<'t> {
+impl Debug for TreeNode<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             TreeNode::Internal { hash, left, right } => f

--- a/lib/b3fs/src/collections/tree.rs
+++ b/lib/b3fs/src/collections/tree.rs
@@ -19,14 +19,14 @@ use tokio_stream::Stream;
 
 use super::error::CollectionTryFromError;
 use super::flat::FlatHashSlice;
-use crate::bucket::errors::ReadError;
 use crate::bucket::POSITION_START_HASHES;
+use crate::bucket::errors::ReadError;
 use crate::entry::BorrowedEntry;
 use crate::hasher;
 use crate::hasher::dir_hasher::DirectoryHasher;
+use crate::stream::ProofEncoder;
 use crate::stream::buffer::ProofBuf;
 use crate::stream::walker::{self, Mode, TreeWalker};
-use crate::stream::ProofEncoder;
 use crate::utils::{block_counter_from_tree_index, is_valid_tree_len, tree_index};
 
 /// A wrapper around a list of hashes that provides access only to the leaf nodes in the tree.
@@ -82,7 +82,7 @@ impl<'s> TryFrom<&'s Vec<[u8; 32]>> for HashTree<'s> {
     }
 }
 
-impl<'s> Index<usize> for HashTree<'s> {
+impl Index<usize> for HashTree<'_> {
     type Output = [u8; 32];
 
     #[inline]
@@ -184,7 +184,7 @@ impl<'s> Iterator for HashTreeIter<'s> {
     }
 }
 
-impl<'s> DoubleEndedIterator for HashTreeIter<'s> {
+impl DoubleEndedIterator for HashTreeIter<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
         if self.is_done() {
             return None;
@@ -200,7 +200,7 @@ impl<'s> DoubleEndedIterator for HashTreeIter<'s> {
     }
 }
 
-impl<'s> Debug for HashTree<'s> {
+impl Debug for HashTree<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         super::printer::print(self, f)
     }

--- a/lib/b3fs/src/collections/tree.rs
+++ b/lib/b3fs/src/collections/tree.rs
@@ -19,14 +19,14 @@ use tokio_stream::Stream;
 
 use super::error::CollectionTryFromError;
 use super::flat::FlatHashSlice;
-use crate::bucket::POSITION_START_HASHES;
 use crate::bucket::errors::ReadError;
+use crate::bucket::POSITION_START_HASHES;
 use crate::entry::BorrowedEntry;
 use crate::hasher;
 use crate::hasher::dir_hasher::DirectoryHasher;
-use crate::stream::ProofEncoder;
 use crate::stream::buffer::ProofBuf;
 use crate::stream::walker::{self, Mode, TreeWalker};
+use crate::stream::ProofEncoder;
 use crate::utils::{block_counter_from_tree_index, is_valid_tree_len, tree_index};
 
 /// A wrapper around a list of hashes that provides access only to the leaf nodes in the tree.
@@ -268,7 +268,8 @@ where
                 .collect();
 
             // Store the entire page of hashes
-            self.pages[page_index] = Some(hashes.into_boxed_slice()); // Store as boxed slice of hashes
+            self.pages[page_index] = Some(hashes.into_boxed_slice()); // Store as boxed slice of
+                                                                      // hashes
         }
 
         // Retrieve the hash from the loaded page

--- a/lib/b3fs/src/stream/encoder.rs
+++ b/lib/b3fs/src/stream/encoder.rs
@@ -19,7 +19,7 @@ impl ProofEncoder {
     pub fn new(n: usize) -> Self {
         // Compute the byte capacity for this encoder, which is 32-byte per hash and 1
         // byte per 8 one of these.
-        let capacity = n * 32 + (n + 8 - 1) / 8;
+        let capacity = n * 32 + n.div_ceil(8);
         let mut vec = vec![0; capacity];
 
         let buffer = vec.into_boxed_slice();

--- a/lib/b3fs/src/stream/pretty.rs
+++ b/lib/b3fs/src/stream/pretty.rs
@@ -16,7 +16,7 @@ impl<'b> ProofBufPrettyPrinter<'b> {
     }
 }
 
-impl<'b> Debug for ProofBufPrettyPrinter<'b> {
+impl Debug for ProofBufPrettyPrinter<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let iter = ProofBufIter::new(self.0);
         let mut fmt = f.debug_list();
@@ -28,7 +28,7 @@ impl<'b> Debug for ProofBufPrettyPrinter<'b> {
     }
 }
 
-impl<'b> Display for ProofBufPrettyPrinter<'b> {
+impl Display for ProofBufPrettyPrinter<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         Debug::fmt(self, f)
     }
@@ -36,7 +36,7 @@ impl<'b> Display for ProofBufPrettyPrinter<'b> {
 
 struct Item<'h>(bool, &'h [u8; 32]);
 
-impl<'h> Debug for Item<'h> {
+impl Debug for Item<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if self.0 {
             write!(f, "-{}", to_hex(self.1))
@@ -46,7 +46,7 @@ impl<'h> Debug for Item<'h> {
     }
 }
 
-impl<'b> Deref for ProofBufPrettyPrinter<'b> {
+impl Deref for ProofBufPrettyPrinter<'_> {
     type Target = [u8];
 
     #[inline]

--- a/lib/b3fs/src/stream/verifier.rs
+++ b/lib/b3fs/src/stream/verifier.rs
@@ -381,11 +381,9 @@ mod tests {
                 assert!(!verifier.is_finished());
 
                 // test against a wrong proof string.
-                assert!(
-                    verifier
-                        .feed_proof(hashtree.generate_proof(Mode::Initial, i).as_slice())
-                        .is_err()
-                );
+                assert!(verifier
+                    .feed_proof(hashtree.generate_proof(Mode::Initial, i).as_slice())
+                    .is_err());
 
                 verifier
                     .feed_proof(hashtree.generate_proof(Mode::Proceeding, i).as_slice())

--- a/lib/b3fs/src/utils.rs
+++ b/lib/b3fs/src/utils.rs
@@ -208,7 +208,7 @@ pub const fn le_bytes_from_words_32(words: &[u32; 8]) -> [u8; 32] {
 /// Used internally as a helper to pretty print hashes as hex strings.
 pub struct Digest<'d>(pub &'d [u8; 32]);
 
-impl<'d> Debug for Digest<'d> {
+impl Debug for Digest<'_> {
     #[inline(always)]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", to_hex(self.0))

--- a/lib/b3fs/src/utils.rs
+++ b/lib/b3fs/src/utils.rs
@@ -71,8 +71,8 @@ pub const fn block_counter_from_tree_index(index: usize) -> Option<usize> {
         // =floor(log2(x + 1))
         let exp = usize::BITS - (x + 1).leading_zeros() - 1;
         let m = 1usize << (exp - 1); // 2^(exp - 1)
-        // find our position in the right subtree and perform
-        // the next step recursivly.
+                                     // find our position in the right subtree and perform
+                                     // the next step recursivly.
         x -= 2 * m - 1;
         // our index is at least as largest as all of the items in our left
         // subtree. All of the `m`s we are adding are unique power of twos

--- a/lib/better-shutdown/src/completion_fut.rs
+++ b/lib/better-shutdown/src/completion_fut.rs
@@ -24,7 +24,7 @@ impl<'a> CompletionFuture<'a> {
     }
 }
 
-impl<'a> Future for CompletionFuture<'a> {
+impl Future for CompletionFuture<'_> {
     type Output = ();
 
     fn poll(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
@@ -34,7 +34,7 @@ impl<'a> Future for CompletionFuture<'a> {
     }
 }
 
-impl<'a> Drop for CompletionFuture<'a> {
+impl Drop for CompletionFuture<'_> {
     fn drop(&mut self) {
         if let Some(slot) = self.list_position.take() {
             let mut wait_list = self

--- a/lib/better-shutdown/src/signal_fut.rs
+++ b/lib/better-shutdown/src/signal_fut.rs
@@ -4,7 +4,7 @@ use std::task::Poll;
 
 use futures::Future;
 
-use crate::shared::{NUM_SHARED_SHARDS, SharedState};
+use crate::shared::{SharedState, NUM_SHARED_SHARDS};
 use crate::wait_list::{WaitList, WaitListSlotPos};
 
 /// A future that is resolved once the shutdown is triggered. It has the life time of the

--- a/lib/better-shutdown/src/signal_fut.rs
+++ b/lib/better-shutdown/src/signal_fut.rs
@@ -4,7 +4,7 @@ use std::task::Poll;
 
 use futures::Future;
 
-use crate::shared::{SharedState, NUM_SHARED_SHARDS};
+use crate::shared::{NUM_SHARED_SHARDS, SharedState};
 use crate::wait_list::{WaitList, WaitListSlotPos};
 
 /// A future that is resolved once the shutdown is triggered. It has the life time of the
@@ -34,7 +34,7 @@ impl<'a> ShutdownSignal<'a> {
     }
 }
 
-impl<'a> Future for ShutdownSignal<'a> {
+impl Future for ShutdownSignal<'_> {
     type Output = ();
 
     fn poll(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
@@ -51,7 +51,7 @@ impl<'a> Future for ShutdownSignal<'a> {
     }
 }
 
-impl<'a> Drop for ShutdownSignal<'a> {
+impl Drop for ShutdownSignal<'_> {
     fn drop(&mut self) {
         if let Some(slot) = self.list_position.take() {
             let mut wait_list = self.shard.unwrap().lock().expect("wait_list lock poisoned");

--- a/lib/blake3-tree/src/directory/test_utils.rs
+++ b/lib/blake3-tree/src/directory/test_utils.rs
@@ -5,7 +5,7 @@ pub fn name(i: usize) -> &'static str {
     const CHARS: &str = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
     const N: usize = CHARS.len();
     let offset = i % N;
-    let len = (i + N - 1) / N;
+    let len = i.div_ceil(N);
     &CHARS[offset..][..len]
 }
 

--- a/lib/blake3-tree/src/lib.rs
+++ b/lib/blake3-tree/src/lib.rs
@@ -416,7 +416,7 @@ impl ProofEncoder {
     pub fn new(n: usize) -> Self {
         // Compute the byte capacity for this encoder, which is 32-byte per hash and 1
         // byte per 8 one of these.
-        let capacity = n * 32 + (n + 8 - 1) / 8;
+        let capacity = n * 32 + n.div_ceil(8);
         // Create a `Vec<u8>` with the given size and set its len to the byte capacity
         // it is not important for us to take care of initializing the items since the
         // type is a u8 and has no drop logic except the deallocatation of the slice
@@ -713,7 +713,7 @@ fn previous_pow_of_two(n: usize) -> usize {
 #[inline(always)]
 fn is_valid_proof_len(n: usize) -> bool {
     const SEG_SIZE: usize = 32 * 8 + 1;
-    let sign_bytes = (n + SEG_SIZE - 1) / SEG_SIZE;
+    let sign_bytes = n.div_ceil(SEG_SIZE);
     let hash_bytes = n - sign_bytes;
     hash_bytes & 31 == 0 && n <= 32 * 47 + 6 && ((hash_bytes / 32) >= 2 || n == 0)
 }

--- a/lib/fleek-crypto/src/keys/pk.rs
+++ b/lib/fleek-crypto/src/keys/pk.rs
@@ -19,9 +19,7 @@ macro_rules! impl_pk_sig {
         $pk_name:ident, $pk_size:expr, $pk_fc:ident,
         $sig_name:ident, $sig_size:expr, $sig_fc:ident
     ) => {
-        impl_pk_sig!(
-            $pk_name, $pk_size, $pk_fc, $sig_name, $sig_size, $sig_fc, verify
-        );
+        impl_pk_sig!($pk_name, $pk_size, $pk_fc, $sig_name, $sig_size, $sig_fc, verify);
     };
 
     (

--- a/lib/fleek-crypto/src/tests.rs
+++ b/lib/fleek-crypto/src/tests.rs
@@ -61,14 +61,12 @@ fn test_consensus_aggregate_signature_verify() {
     let sig3 = sk3.sign(&[3; 32]);
 
     let agg_sig = ConsensusAggregateSignature::aggregate(&[&sig1, &sig2, &sig3]).unwrap();
-    assert!(
-        agg_sig
-            .verify(
-                &[sk1.to_pk(), sk2.to_pk(), sk3.to_pk()],
-                &[&[1; 32], &[2; 32], &[3; 32]],
-            )
-            .unwrap()
-    );
+    assert!(agg_sig
+        .verify(
+            &[sk1.to_pk(), sk2.to_pk(), sk3.to_pk()],
+            &[&[1; 32], &[2; 32], &[3; 32]],
+        )
+        .unwrap());
 
     // Should return error if signature has invalid bytes.
     assert_eq!(

--- a/lib/fleek-ipld/examples/controlled.rs
+++ b/lib/fleek-ipld/examples/controlled.rs
@@ -26,7 +26,7 @@ impl IpldItemProcessor for PrintProcessor {
 #[tokio::main]
 async fn main() -> Result<(), Box<(dyn std::error::Error + 'static)>> {
     let cid: Cid = "QmSnuWmxptJZdLJpKRarxBMS2Ju2oANVrgbr2xWbie9b2D".try_into()?; // all
-    //let cid: Cid = "Qmb4KDzrnDHdHcH1UUTF3jTC3RhPJ6UyZ2wB8fNPnwiP5R".try_into()?; // all
+                                                                                 //let cid: Cid = "Qmb4KDzrnDHdHcH1UUTF3jTC3RhPJ6UyZ2wB8fNPnwiP5R".try_into()?; // all
 
     //let cid: Cid = "Qmc8mmzycvXnzgwBHokZQd97iWAmtdFMqX4FZUAQ5AQdQi".try_into()?; // jpg big file
     //let cid: Cid = "Qmej4L6L4UYxHF4s4QeAzkwUX8VZ45GiuZ2BLtVds5LXad".try_into()?; // css file

--- a/lib/fleek-ipld/examples/one_shot_all.rs
+++ b/lib/fleek-ipld/examples/one_shot_all.rs
@@ -23,11 +23,11 @@ impl IpldItemProcessor for PrintProcessor {
 #[tokio::main]
 async fn main() -> Result<(), Box<(dyn std::error::Error + 'static)>> {
     let cid: Cid = "QmSnuWmxptJZdLJpKRarxBMS2Ju2oANVrgbr2xWbie9b2D".try_into()?; // all
-    //let cid: Cid = "QmVtxWYYaGKVrfiwSGn8s1ifJi4nvxwC7HE14ZbMtC4DeM".try_into()?; // all
-    //let cid: Cid = "Qmb4KDzrnDHdHcH1UUTF3jTC3RhPJ6UyZ2wB8fNPnwiP5R".try_into()?; // all
-    //let cid: Cid = "Qmc8mmzycvXnzgwBHokZQd97iWAmtdFMqX4FZUAQ5AQdQi".try_into()?; // jpg big file
-    //let cid: Cid = "Qmej4L6L4UYxHF4s4QeAzkwUX8VZ45GiuZ2BLtVds5LXad".try_into()?; // css file
-    //let cid: Cid = "QmbvrHYWXAU1BuxMPNRtfeF4DS2oPmo5hat7ocqAkNPr74".try_into()?; // png small
+                                                                                 //let cid: Cid = "QmVtxWYYaGKVrfiwSGn8s1ifJi4nvxwC7HE14ZbMtC4DeM".try_into()?; // all
+                                                                                 //let cid: Cid = "Qmb4KDzrnDHdHcH1UUTF3jTC3RhPJ6UyZ2wB8fNPnwiP5R".try_into()?; // all
+                                                                                 //let cid: Cid = "Qmc8mmzycvXnzgwBHokZQd97iWAmtdFMqX4FZUAQ5AQdQi".try_into()?; // jpg big file
+                                                                                 //let cid: Cid = "Qmej4L6L4UYxHF4s4QeAzkwUX8VZ45GiuZ2BLtVds5LXad".try_into()?; // css file
+                                                                                 //let cid: Cid = "QmbvrHYWXAU1BuxMPNRtfeF4DS2oPmo5hat7ocqAkNPr74".try_into()?; // png small
 
     let processor = PrintProcessor;
     let downloader = ReqwestDownloader::new("https://ipfs.io");

--- a/lib/hp-fixed/src/signed.rs
+++ b/lib/hp-fixed/src/signed.rs
@@ -102,11 +102,19 @@ impl<const P: usize> HpFixed<P> {
     }
 
     pub fn min<'a>(&'a self, rhs: &'a Self) -> &'a Self {
-        if self.0 <= rhs.0 { self } else { rhs }
+        if self.0 <= rhs.0 {
+            self
+        } else {
+            rhs
+        }
     }
 
     pub fn max<'a>(&'a self, rhs: &'a Self) -> &'a Self {
-        if self.0 >= rhs.0 { self } else { rhs }
+        if self.0 >= rhs.0 {
+            self
+        } else {
+            rhs
+        }
     }
 
     pub fn try_abs(&self) -> Option<HpFixed<P>> {

--- a/lib/hp-fixed/src/unsigned.rs
+++ b/lib/hp-fixed/src/unsigned.rs
@@ -85,11 +85,19 @@ impl<const P: usize> HpUfixed<P> {
     }
 
     pub fn min<'a>(&'a self, rhs: &'a Self) -> &'a Self {
-        if self.0 <= rhs.0 { self } else { rhs }
+        if self.0 <= rhs.0 {
+            self
+        } else {
+            rhs
+        }
     }
 
     pub fn max<'a>(&'a self, rhs: &'a Self) -> &'a Self {
-        if self.0 >= rhs.0 { self } else { rhs }
+        if self.0 >= rhs.0 {
+            self
+        } else {
+            rhs
+        }
     }
 
     pub fn get_value(&self) -> &U256 {

--- a/lib/ink-quill/src/lib.rs
+++ b/lib/ink-quill/src/lib.rs
@@ -328,7 +328,7 @@ impl TranscriptBuilderInput for Option<String> {
     }
 }
 
-impl<'a> TranscriptBuilderInput for &'a str {
+impl TranscriptBuilderInput for &str {
     const TYPE: &'static str = "str";
 
     fn to_transcript_builder_input(&self) -> Vec<u8> {

--- a/lib/merklize/src/trees/jmt/adapter.rs
+++ b/lib/merklize/src/trees/jmt/adapter.rs
@@ -54,7 +54,7 @@ impl<'a, B: StorageBackend, S: SerdeBackend> Adapter<'a, B, S> {
     }
 }
 
-impl<'a, B: StorageBackend, S: SerdeBackend> TreeReader for Adapter<'a, B, S> {
+impl<B: StorageBackend, S: SerdeBackend> TreeReader for Adapter<'_, B, S> {
     /// Get the node for the given node key, if it is present in the tree.
     fn get_node_option(&self, node_key: &NodeKey) -> Result<Option<Node>> {
         let value = self.nodes_table.lock().unwrap().get(node_key);
@@ -99,7 +99,7 @@ impl<'a, B: StorageBackend, S: SerdeBackend> TreeReader for Adapter<'a, B, S> {
     }
 }
 
-impl<'a, B: StorageBackend, S: SerdeBackend> HasPreimage for Adapter<'a, B, S> {
+impl<B: StorageBackend, S: SerdeBackend> HasPreimage for Adapter<'_, B, S> {
     /// Gets the preimage of a key hash, if it is present in the tree.
     fn preimage(&self, key_hash: KeyHash) -> Result<Option<Vec<u8>>> {
         let state_key = self.get_key(key_hash);

--- a/lib/merklize/src/trees/mpt/adapter.rs
+++ b/lib/merklize/src/trees/mpt/adapter.rs
@@ -37,7 +37,7 @@ where
     }
 }
 
-impl<'a, B, S, H> HashDB<SimpleHasherWrapper<H>, DBValue> for Adapter<'a, B, S, H>
+impl<B, S, H> HashDB<SimpleHasherWrapper<H>, DBValue> for Adapter<'_, B, S, H>
 where
     B: StorageBackend + Send + Sync,
     S: SerdeBackend + Send + Sync,
@@ -124,7 +124,7 @@ where
     }
 }
 
-impl<'a, B, S, H> HashDBRef<SimpleHasherWrapper<H>, DBValue> for Adapter<'a, B, S, H>
+impl<B, S, H> HashDBRef<SimpleHasherWrapper<H>, DBValue> for Adapter<'_, B, S, H>
 where
     B: StorageBackend + Send + Sync,
     S: SerdeBackend + Send + Sync,
@@ -146,7 +146,7 @@ where
     }
 }
 
-impl<'a, B, S, H> AsHashDB<SimpleHasherWrapper<H>, DBValue> for Adapter<'a, B, S, H>
+impl<B, S, H> AsHashDB<SimpleHasherWrapper<H>, DBValue> for Adapter<'_, B, S, H>
 where
     B: StorageBackend + Send + Sync,
     S: SerdeBackend + Send + Sync,

--- a/lib/panic-report/src/lib.rs
+++ b/lib/panic-report/src/lib.rs
@@ -2,7 +2,7 @@
 
 use std::backtrace::Backtrace;
 use std::collections::BTreeMap;
-use std::panic::PanicInfo;
+use std::panic::PanicHookInfo;
 use std::path::PathBuf;
 use std::sync::Mutex;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -192,7 +192,7 @@ pub struct Report {
 impl Report {
     /// Capture a new report with the information, context, and backtrace.
     #[inline(always)]
-    pub fn new(info: &PanicInfo, backtrace: &Backtrace, name: &str, version: &str) -> Self {
+    pub fn new(info: &PanicHookInfo, backtrace: &Backtrace, name: &str, version: &str) -> Self {
         let timestamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()

--- a/lib/sdk/src/blockstore.rs
+++ b/lib/sdk/src/blockstore.rs
@@ -13,16 +13,19 @@ use crate::ipc::BLOCKSTORE;
 ///
 /// If called from outside of a service execution.
 pub async fn blockstore_root() -> Bucket {
+    #[allow(static_mut_refs)]
     let path = unsafe { BLOCKSTORE.as_ref().expect("setup not completed") };
     Bucket::open(path).await.expect("Error opening bucket")
 }
 
 pub fn header_file(hash: &[u8; 32]) -> PathBuf {
+    #[allow(static_mut_refs)]
     let path = unsafe { BLOCKSTORE.as_ref().expect("setup not completed") };
     Bucket::header_path(path, hash).expect("Error opening header path")
 }
 
 pub fn block_file(hash: &[u8; 32]) -> PathBuf {
+    #[allow(static_mut_refs)]
     let path = unsafe { BLOCKSTORE.as_ref().expect("setup not completed") };
     Bucket::block_path(path, hash).expect("Error opening header path")
 }

--- a/lib/sdk/src/ipc.rs
+++ b/lib/sdk/src/ipc.rs
@@ -18,7 +18,7 @@ use tokio::sync::mpsc;
 
 use crate::connection::ConnectionListener;
 use crate::futures::future_callback;
-use crate::ipc_types::{DELIMITER_SIZE, IpcMessage, IpcRequest, Request, Response};
+use crate::ipc_types::{IpcMessage, IpcRequest, Request, Response, DELIMITER_SIZE};
 
 static mut SENDER: Option<tokio::sync::mpsc::Sender<IpcRequest>> = None;
 pub(crate) static mut IPC_PATH: Option<PathBuf> = None;
@@ -318,9 +318,10 @@ mod tests {
             }
             let req = IpcRequest::decode(&buffer).unwrap();
 
-            assert_eq!(req.request, Request::QueryClientBandwidth {
-                pk: [i; 96].into()
-            });
+            assert_eq!(
+                req.request,
+                Request::QueryClientBandwidth { pk: [i; 96].into() }
+            );
 
             let result = IpcMessage::Response {
                 request_ctx: req.request_ctx.unwrap(),
@@ -348,9 +349,12 @@ mod tests {
             }
 
             let result = send_task.await.unwrap();
-            assert_eq!(result, Response::QueryClientBandwidth {
-                balance: i as u128 + 100
-            });
+            assert_eq!(
+                result,
+                Response::QueryClientBandwidth {
+                    balance: i as u128 + 100
+                }
+            );
         }
         let took = started.elapsed();
         println!("took {took:?}");

--- a/lib/simulon/src/simulation.rs
+++ b/lib/simulon/src/simulation.rs
@@ -10,7 +10,7 @@ use triomphe::Arc;
 use crate::latency::{DefaultLatencyProvider, LatencyProvider};
 use crate::message::Message;
 use crate::report::{Metrics, Report};
-use crate::state::{NodeState, hook_node, with_node};
+use crate::state::{hook_node, with_node, NodeState};
 use crate::storage::TypedStorage;
 use crate::{FRAME_DURATION, FRAME_TO_MS};
 

--- a/lib/simulon/src/simulation.rs
+++ b/lib/simulon/src/simulation.rs
@@ -10,7 +10,7 @@ use triomphe::Arc;
 use crate::latency::{DefaultLatencyProvider, LatencyProvider};
 use crate::message::Message;
 use crate::report::{Metrics, Report};
-use crate::state::{hook_node, with_node, NodeState};
+use crate::state::{NodeState, hook_node, with_node};
 use crate::storage::TypedStorage;
 use crate::{FRAME_DURATION, FRAME_TO_MS};
 
@@ -367,7 +367,7 @@ impl<L: LatencyProvider> Simulation<L> {
         let time = msg.time.0;
 
         debug_assert!(time > self.now);
-        Some(ceil_div(time - self.now, FRAME_DURATION.as_nanos()).max(1) as usize)
+        Some((time - self.now).div_ceil(FRAME_DURATION.as_nanos()).max(1) as usize)
     }
 
     fn start_threads(&mut self) {
@@ -503,9 +503,4 @@ fn wait_for_workers(state: &Arc<SharedState>) {
 
         std::hint::spin_loop();
     }
-}
-
-#[inline(always)]
-fn ceil_div(a: u128, b: u128) -> u128 {
-    (a + b - 1) / b
 }

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2024-06-25"
+channel = "nightly-2025-01-02"
 components = ["cargo", "rust-std", "rust-src", "rustc", "rustfmt", "clippy"]
 targets = [ "x86_64-fortanix-unknown-sgx", "wasm32-unknown-unknown" ]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,5 +1,5 @@
 edition = "2021"
-version = "Two"
+style_edition = "2021"
 
 imports_layout = "HorizontalVertical"
 imports_granularity = "Module"

--- a/services/ai/examples/rust/vision/examples/resnet.rs
+++ b/services/ai/examples/rust/vision/examples/resnet.rs
@@ -25,7 +25,7 @@ async fn main() {
     for pixel in img.pixels() {
         let x = pixel.0 as _;
         let y = pixel.1 as _;
-        let [r, g, b, _] = pixel.2.0;
+        let [r, g, b, _] = pixel.2 .0;
         input[[0, 0, y, x]] = (r as f32) / 255.;
         input[[0, 1, y, x]] = (g as f32) / 255.;
         input[[0, 2, y, x]] = (b as f32) / 255.;

--- a/services/ai/src/opts.rs
+++ b/services/ai/src/opts.rs
@@ -168,7 +168,7 @@ impl TryFrom<u8> for BorshVectorType {
             _ => {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::InvalidInput,
-                    "unknown encoding {value}",
+                    format!("unknown encoding {value}"),
                 ));
             },
         };

--- a/services/ai/src/runtime/serialize.rs
+++ b/services/ai/src/runtime/serialize.rs
@@ -81,10 +81,13 @@ pub fn borsh_serialize_outputs(
                         bail!("cannot serialize array with dim {dim:?} using borsh");
                     } else {
                         let array = array.into_iter().collect::<Vec<i8>>();
-                        borsh_out.insert(name, BorshVector {
-                            dtype: BorshVectorType::Int8,
-                            data: borsh::to_vec::<Vec<i8>>(&array)?,
-                        });
+                        borsh_out.insert(
+                            name,
+                            BorshVector {
+                                dtype: BorshVectorType::Int8,
+                                data: borsh::to_vec::<Vec<i8>>(&array)?,
+                            },
+                        );
                     }
                 },
                 TensorElementType::Int16 => {
@@ -93,10 +96,13 @@ pub fn borsh_serialize_outputs(
                         bail!("cannot serialize array with dim {dim:?} using borsh");
                     } else {
                         let array = array.into_iter().collect::<Vec<i16>>();
-                        borsh_out.insert(name, BorshVector {
-                            dtype: BorshVectorType::Int8,
-                            data: borsh::to_vec::<Vec<i16>>(&array)?,
-                        });
+                        borsh_out.insert(
+                            name,
+                            BorshVector {
+                                dtype: BorshVectorType::Int8,
+                                data: borsh::to_vec::<Vec<i16>>(&array)?,
+                            },
+                        );
                     }
                 },
                 TensorElementType::Int32 => {
@@ -105,10 +111,13 @@ pub fn borsh_serialize_outputs(
                         bail!("cannot serialize array with dim {dim:?} using borsh");
                     } else {
                         let array = array.into_iter().collect::<Vec<i32>>();
-                        borsh_out.insert(name, BorshVector {
-                            dtype: BorshVectorType::Int8,
-                            data: borsh::to_vec::<Vec<i32>>(&array)?,
-                        });
+                        borsh_out.insert(
+                            name,
+                            BorshVector {
+                                dtype: BorshVectorType::Int8,
+                                data: borsh::to_vec::<Vec<i32>>(&array)?,
+                            },
+                        );
                     }
                 },
                 TensorElementType::Int64 => {
@@ -117,10 +126,13 @@ pub fn borsh_serialize_outputs(
                         bail!("cannot serialize array with dim {dim:?} using borsh");
                     } else {
                         let array = array.into_iter().collect::<Vec<i64>>();
-                        borsh_out.insert(name, BorshVector {
-                            dtype: BorshVectorType::Int8,
-                            data: borsh::to_vec::<Vec<i64>>(&array)?,
-                        });
+                        borsh_out.insert(
+                            name,
+                            BorshVector {
+                                dtype: BorshVectorType::Int8,
+                                data: borsh::to_vec::<Vec<i64>>(&array)?,
+                            },
+                        );
                     }
                 },
                 TensorElementType::Uint8 => {
@@ -129,10 +141,13 @@ pub fn borsh_serialize_outputs(
                         bail!("cannot serialize array with dim {dim:?} using borsh");
                     } else {
                         let array = array.into_iter().collect::<Vec<u8>>();
-                        borsh_out.insert(name, BorshVector {
-                            dtype: BorshVectorType::Int8,
-                            data: borsh::to_vec::<Vec<u8>>(&array)?,
-                        });
+                        borsh_out.insert(
+                            name,
+                            BorshVector {
+                                dtype: BorshVectorType::Int8,
+                                data: borsh::to_vec::<Vec<u8>>(&array)?,
+                            },
+                        );
                     }
                 },
                 TensorElementType::Uint16 => {
@@ -141,10 +156,13 @@ pub fn borsh_serialize_outputs(
                         bail!("cannot serialize array with dim {dim:?} using borsh");
                     } else {
                         let array = array.into_iter().collect::<Vec<u16>>();
-                        borsh_out.insert(name, BorshVector {
-                            dtype: BorshVectorType::Int8,
-                            data: borsh::to_vec::<Vec<u16>>(&array)?,
-                        });
+                        borsh_out.insert(
+                            name,
+                            BorshVector {
+                                dtype: BorshVectorType::Int8,
+                                data: borsh::to_vec::<Vec<u16>>(&array)?,
+                            },
+                        );
                     }
                 },
                 TensorElementType::Uint32 => {
@@ -153,10 +171,13 @@ pub fn borsh_serialize_outputs(
                         bail!("cannot serialize array with dim {dim:?} using borsh");
                     } else {
                         let array = array.into_iter().collect::<Vec<u32>>();
-                        borsh_out.insert(name, BorshVector {
-                            dtype: BorshVectorType::Int8,
-                            data: borsh::to_vec::<Vec<u32>>(&array)?,
-                        });
+                        borsh_out.insert(
+                            name,
+                            BorshVector {
+                                dtype: BorshVectorType::Int8,
+                                data: borsh::to_vec::<Vec<u32>>(&array)?,
+                            },
+                        );
                     }
                 },
                 TensorElementType::Uint64 => {
@@ -165,10 +186,13 @@ pub fn borsh_serialize_outputs(
                         bail!("cannot serialize array with dim {dim:?} using borsh");
                     } else {
                         let array = array.into_iter().collect::<Vec<u64>>();
-                        borsh_out.insert(name, BorshVector {
-                            dtype: BorshVectorType::Uint64,
-                            data: borsh::to_vec::<Vec<u64>>(&array)?,
-                        });
+                        borsh_out.insert(
+                            name,
+                            BorshVector {
+                                dtype: BorshVectorType::Uint64,
+                                data: borsh::to_vec::<Vec<u64>>(&array)?,
+                            },
+                        );
                     }
                 },
                 TensorElementType::Float32 => {
@@ -177,10 +201,13 @@ pub fn borsh_serialize_outputs(
                         bail!("cannot serialize array with dim {dim:?} using borsh");
                     } else {
                         let array = array.into_iter().collect::<Vec<f32>>();
-                        borsh_out.insert(name, BorshVector {
-                            dtype: BorshVectorType::Int8,
-                            data: borsh::to_vec::<Vec<f32>>(&array)?,
-                        });
+                        borsh_out.insert(
+                            name,
+                            BorshVector {
+                                dtype: BorshVectorType::Int8,
+                                data: borsh::to_vec::<Vec<f32>>(&array)?,
+                            },
+                        );
                     }
                 },
                 TensorElementType::Float64 => {
@@ -189,10 +216,13 @@ pub fn borsh_serialize_outputs(
                         bail!("cannot serialize array with dim {dim:?} using borsh");
                     } else {
                         let array = array.into_iter().collect::<Vec<f64>>();
-                        borsh_out.insert(name, BorshVector {
-                            dtype: BorshVectorType::Int8,
-                            data: borsh::to_vec::<Vec<f64>>(&array)?,
-                        });
+                        borsh_out.insert(
+                            name,
+                            BorshVector {
+                                dtype: BorshVectorType::Int8,
+                                data: borsh::to_vec::<Vec<f64>>(&array)?,
+                            },
+                        );
                     }
                 },
                 _ => bail!("unsupported value type"),

--- a/services/ai/src/runtime/serialize.rs
+++ b/services/ai/src/runtime/serialize.rs
@@ -62,10 +62,7 @@ pub fn safetensors_serialize_outputs(session_outputs: SessionOutputs) -> anyhow:
         }
     }
 
-    safetensors_out
-        .serialize(&None)
-        .map(Into::into)
-        .map_err(Into::into)
+    safetensors_out.serialize(&None).map(Into::into)
 }
 
 pub fn borsh_serialize_outputs(
@@ -84,13 +81,10 @@ pub fn borsh_serialize_outputs(
                         bail!("cannot serialize array with dim {dim:?} using borsh");
                     } else {
                         let array = array.into_iter().collect::<Vec<i8>>();
-                        borsh_out.insert(
-                            name,
-                            BorshVector {
-                                dtype: BorshVectorType::Int8,
-                                data: borsh::to_vec::<Vec<i8>>(&array)?,
-                            },
-                        );
+                        borsh_out.insert(name, BorshVector {
+                            dtype: BorshVectorType::Int8,
+                            data: borsh::to_vec::<Vec<i8>>(&array)?,
+                        });
                     }
                 },
                 TensorElementType::Int16 => {
@@ -99,13 +93,10 @@ pub fn borsh_serialize_outputs(
                         bail!("cannot serialize array with dim {dim:?} using borsh");
                     } else {
                         let array = array.into_iter().collect::<Vec<i16>>();
-                        borsh_out.insert(
-                            name,
-                            BorshVector {
-                                dtype: BorshVectorType::Int8,
-                                data: borsh::to_vec::<Vec<i16>>(&array)?,
-                            },
-                        );
+                        borsh_out.insert(name, BorshVector {
+                            dtype: BorshVectorType::Int8,
+                            data: borsh::to_vec::<Vec<i16>>(&array)?,
+                        });
                     }
                 },
                 TensorElementType::Int32 => {
@@ -114,13 +105,10 @@ pub fn borsh_serialize_outputs(
                         bail!("cannot serialize array with dim {dim:?} using borsh");
                     } else {
                         let array = array.into_iter().collect::<Vec<i32>>();
-                        borsh_out.insert(
-                            name,
-                            BorshVector {
-                                dtype: BorshVectorType::Int8,
-                                data: borsh::to_vec::<Vec<i32>>(&array)?,
-                            },
-                        );
+                        borsh_out.insert(name, BorshVector {
+                            dtype: BorshVectorType::Int8,
+                            data: borsh::to_vec::<Vec<i32>>(&array)?,
+                        });
                     }
                 },
                 TensorElementType::Int64 => {
@@ -129,13 +117,10 @@ pub fn borsh_serialize_outputs(
                         bail!("cannot serialize array with dim {dim:?} using borsh");
                     } else {
                         let array = array.into_iter().collect::<Vec<i64>>();
-                        borsh_out.insert(
-                            name,
-                            BorshVector {
-                                dtype: BorshVectorType::Int8,
-                                data: borsh::to_vec::<Vec<i64>>(&array)?,
-                            },
-                        );
+                        borsh_out.insert(name, BorshVector {
+                            dtype: BorshVectorType::Int8,
+                            data: borsh::to_vec::<Vec<i64>>(&array)?,
+                        });
                     }
                 },
                 TensorElementType::Uint8 => {
@@ -144,13 +129,10 @@ pub fn borsh_serialize_outputs(
                         bail!("cannot serialize array with dim {dim:?} using borsh");
                     } else {
                         let array = array.into_iter().collect::<Vec<u8>>();
-                        borsh_out.insert(
-                            name,
-                            BorshVector {
-                                dtype: BorshVectorType::Int8,
-                                data: borsh::to_vec::<Vec<u8>>(&array)?,
-                            },
-                        );
+                        borsh_out.insert(name, BorshVector {
+                            dtype: BorshVectorType::Int8,
+                            data: borsh::to_vec::<Vec<u8>>(&array)?,
+                        });
                     }
                 },
                 TensorElementType::Uint16 => {
@@ -159,13 +141,10 @@ pub fn borsh_serialize_outputs(
                         bail!("cannot serialize array with dim {dim:?} using borsh");
                     } else {
                         let array = array.into_iter().collect::<Vec<u16>>();
-                        borsh_out.insert(
-                            name,
-                            BorshVector {
-                                dtype: BorshVectorType::Int8,
-                                data: borsh::to_vec::<Vec<u16>>(&array)?,
-                            },
-                        );
+                        borsh_out.insert(name, BorshVector {
+                            dtype: BorshVectorType::Int8,
+                            data: borsh::to_vec::<Vec<u16>>(&array)?,
+                        });
                     }
                 },
                 TensorElementType::Uint32 => {
@@ -174,13 +153,10 @@ pub fn borsh_serialize_outputs(
                         bail!("cannot serialize array with dim {dim:?} using borsh");
                     } else {
                         let array = array.into_iter().collect::<Vec<u32>>();
-                        borsh_out.insert(
-                            name,
-                            BorshVector {
-                                dtype: BorshVectorType::Int8,
-                                data: borsh::to_vec::<Vec<u32>>(&array)?,
-                            },
-                        );
+                        borsh_out.insert(name, BorshVector {
+                            dtype: BorshVectorType::Int8,
+                            data: borsh::to_vec::<Vec<u32>>(&array)?,
+                        });
                     }
                 },
                 TensorElementType::Uint64 => {
@@ -189,13 +165,10 @@ pub fn borsh_serialize_outputs(
                         bail!("cannot serialize array with dim {dim:?} using borsh");
                     } else {
                         let array = array.into_iter().collect::<Vec<u64>>();
-                        borsh_out.insert(
-                            name,
-                            BorshVector {
-                                dtype: BorshVectorType::Uint64,
-                                data: borsh::to_vec::<Vec<u64>>(&array)?,
-                            },
-                        );
+                        borsh_out.insert(name, BorshVector {
+                            dtype: BorshVectorType::Uint64,
+                            data: borsh::to_vec::<Vec<u64>>(&array)?,
+                        });
                     }
                 },
                 TensorElementType::Float32 => {
@@ -204,13 +177,10 @@ pub fn borsh_serialize_outputs(
                         bail!("cannot serialize array with dim {dim:?} using borsh");
                     } else {
                         let array = array.into_iter().collect::<Vec<f32>>();
-                        borsh_out.insert(
-                            name,
-                            BorshVector {
-                                dtype: BorshVectorType::Int8,
-                                data: borsh::to_vec::<Vec<f32>>(&array)?,
-                            },
-                        );
+                        borsh_out.insert(name, BorshVector {
+                            dtype: BorshVectorType::Int8,
+                            data: borsh::to_vec::<Vec<f32>>(&array)?,
+                        });
                     }
                 },
                 TensorElementType::Float64 => {
@@ -219,13 +189,10 @@ pub fn borsh_serialize_outputs(
                         bail!("cannot serialize array with dim {dim:?} using borsh");
                     } else {
                         let array = array.into_iter().collect::<Vec<f64>>();
-                        borsh_out.insert(
-                            name,
-                            BorshVector {
-                                dtype: BorshVectorType::Int8,
-                                data: borsh::to_vec::<Vec<f64>>(&array)?,
-                            },
-                        );
+                        borsh_out.insert(name, BorshVector {
+                            dtype: BorshVectorType::Int8,
+                            data: borsh::to_vec::<Vec<f64>>(&array)?,
+                        });
                     }
                 },
                 _ => bail!("unsupported value type"),

--- a/services/js-poc/src/http/response.rs
+++ b/services/js-poc/src/http/response.rs
@@ -137,12 +137,10 @@ fn parse_headers(headers: &serde_json::Value) -> Result<Vec<(String, Vec<String>
 
                 headers.push((
                     key.to_owned(),
-                    vec![
-                        value
-                            .as_str()
-                            .context("Failed to convert value to string")?
-                            .to_string(),
-                    ],
+                    vec![value
+                        .as_str()
+                        .context("Failed to convert value to string")?
+                        .to_string()],
                 ));
             } else if let Some(array) = value.as_array() {
                 // At this point the array either consists of header values corresponding to
@@ -213,10 +211,9 @@ fn parse_header(value: &serde_json::Value) -> Result<(String, Vec<String>)> {
         match arr.as_slice() {
             // TODO: verify correctness of allowing empty headers
             [serde_json::Value::String(key)] => Ok((key.clone(), vec![])),
-            [
-                serde_json::Value::String(key),
-                serde_json::Value::Array(arr),
-            ] => Ok((key.clone(), arr.iter().map(value_to_string).collect())),
+            [serde_json::Value::String(key), serde_json::Value::Array(arr)] => {
+                Ok((key.clone(), arr.iter().map(value_to_string).collect()))
+            },
             [serde_json::Value::String(key), _, ..] => {
                 Ok((key.clone(), arr[1..].iter().map(value_to_string).collect()))
             },

--- a/services/js-poc/src/runtime/guard.rs
+++ b/services/js-poc/src/runtime/guard.rs
@@ -22,7 +22,7 @@ impl IsolateGuard {
         Self { rt }
     }
 
-    pub fn guard<'a, F>(&'a mut self, f: F) -> GuardedIsolateFuture
+    pub fn guard<'a, F>(&'a mut self, f: F) -> GuardedIsolateFuture<'a>
     where
         F: FnOnce(&'a mut Runtime) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + 'a>>,
     {
@@ -43,7 +43,7 @@ pub struct GuardedIsolateFuture<'a> {
     fut: Pin<Box<dyn Future<Output = anyhow::Result<()>> + 'a>>,
 }
 
-impl<'a> GuardedIsolateFuture<'a> {
+impl GuardedIsolateFuture<'_> {
     fn enter(&mut self) {
         let runtime = unsafe { self.ptr.as_mut().expect("Pointer to be non-null") };
         unsafe {
@@ -59,7 +59,7 @@ impl<'a> GuardedIsolateFuture<'a> {
     }
 }
 
-impl<'a> Future for GuardedIsolateFuture<'a> {
+impl Future for GuardedIsolateFuture<'_> {
     type Output = anyhow::Result<()>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {


### PR DESCRIPTION
Bump project to 2025-01-02 nightly (rust 1.85)

- Required for new deno versions
- Fixed newly elided lifetimes lints
- Fixed manually implemented `a.div_ceil(b)` clippy lints
- Fixed `map_or(false, ...)` -> `is_some_and(...)` lints