### PR TITLE
feat: add mints to state table

### DIFF
--- a/core/application/src/state/executor.rs
+++ b/core/application/src/state/executor.rs
@@ -28,6 +28,7 @@ use lightning_interfaces::types::{
     ExecutionData,
     ExecutionError,
     Metadata,
+    MintInfo,
     NodeIndex,
     NodeInfo,
     NodePorts,
@@ -136,6 +137,7 @@ pub struct StateExecutor<B: Backend> {
     >,
     pub committee_selection_beacon_non_revealing_node: B::Ref<NodeIndex, ()>,
     pub withdraws: B::Ref<u64, WithdrawInfo>,
+    pub mints: B::Ref<[u8; 32], MintInfo>,
     pub backend: B,
 }
 
@@ -168,6 +170,7 @@ impl<B: Backend> StateExecutor<B> {
             committee_selection_beacon_non_revealing_node: backend
                 .get_table_reference("committee_selection_beacon_non_revealing_node"),
             withdraws: backend.get_table_reference("withdraws"),
+            mints: backend.get_table_reference("mints"),
             backend,
         }
     }
@@ -211,7 +214,16 @@ impl<B: Backend> StateExecutor<B> {
                 amount,
                 token,
                 receiving_address,
-            } => self.mint(txn.payload.sender, receiving_address, amount, token),
+                eth_tx_hash,
+                block_number,
+            } => self.mint(
+                txn.payload.sender,
+                receiving_address,
+                amount,
+                token,
+                eth_tx_hash,
+                block_number,
+            ),
 
             UpdateMethod::Deposit {
                 proof,
@@ -554,6 +566,8 @@ impl<B: Backend> StateExecutor<B> {
         reciever: EthAddress,
         amount: HpUfixed<18>,
         token: Tokens,
+        eth_tx_hash: [u8; 32],
+        block_number: u64,
     ) -> TransactionResponse {
         // This transaction is only callable by AccountOwners and not nodes
         // So revert if the sender is a node public key
@@ -572,10 +586,24 @@ impl<B: Backend> StateExecutor<B> {
 
         let mut account = self.account_info.get(&reciever).unwrap_or_default();
 
+        if self.mints.get(&eth_tx_hash).is_some() {
+            return TransactionResponse::Revert(ExecutionError::AlreadyMinted);
+        }
+
+        let mint_info = MintInfo {
+            amount: amount.clone(),
+            token: token.clone(),
+            receiving_address: reciever,
+            eth_tx_hash,
+            block_number,
+        };
+
+        self.mints.set(eth_tx_hash, mint_info);
+
         // Check the token bridged and increment that amount
         match token {
             Tokens::FLK => account.flk_balance += amount,
-            Tokens::USDC => account.bandwidth_balance += TryInto::<u128>::try_into(amount).unwrap(),
+            Tokens::USDC => account.stables_balance += amount.convert_precision::<6>(),
         }
 
         self.account_info.set(reciever, account);

--- a/core/application/src/state/query.rs
+++ b/core/application/src/state/query.rs
@@ -24,6 +24,7 @@ use lightning_interfaces::types::{
     CommodityTypes,
     Epoch,
     Metadata,
+    MintInfo,
     NodeIndex,
     NodeInfo,
     NodeServed,
@@ -83,6 +84,7 @@ pub struct QueryRunner {
     >,
     committee_selection_beacon_non_revealing_node: ResolvedTableReference<NodeIndex, ()>,
     withdraws: ResolvedTableReference<u64, WithdrawInfo>,
+    mints: ResolvedTableReference<[u8; 32], MintInfo>,
 }
 
 impl QueryRunner {
@@ -127,6 +129,7 @@ impl SyncQueryRunnerInterface for QueryRunner {
             committee_selection_beacon_non_revealing_node: atomo
                 .resolve::<NodeIndex, ()>("committee_selection_beacon_non_revealing_node"),
             withdraws: atomo.resolve::<u64, WithdrawInfo>("withdraws"),
+            mints: atomo.resolve::<[u8; 32], MintInfo>("mints"),
             inner: atomo,
         }
     }
@@ -402,5 +405,10 @@ impl SyncQueryRunnerInterface for QueryRunner {
             .filter(|info| info.id >= paging.start)
             .take(paging.limit)
             .collect()
+    }
+
+    fn has_minted(&self, tx_hash: [u8; 32]) -> bool {
+        self.inner
+            .run(|ctx| self.mints.get(ctx).get(tx_hash).is_some())
     }
 }

--- a/core/application/src/state/writer.rs
+++ b/core/application/src/state/writer.rs
@@ -24,6 +24,7 @@ use lightning_interfaces::types::{
     CommodityTypes,
     Epoch,
     Metadata,
+    MintInfo,
     NodeIndex,
     NodeInfo,
     NodeServed,
@@ -190,6 +191,7 @@ impl ApplicationState<AtomoStorage, DefaultSerdeBackend, ApplicationStateTree> {
             )>("committee_selection_beacon")
             .with_table::<NodeIndex, ()>("committee_selection_beacon_non_revealing_node")
             .with_table::<u64, WithdrawInfo>("withdraws")
+            .with_table::<[u8; 32], MintInfo>("mints")
             .enable_iter("current_epoch_served")
             .enable_iter("rep_measurements")
             .enable_iter("submitted_rep_measurements")
@@ -203,6 +205,7 @@ impl ApplicationState<AtomoStorage, DefaultSerdeBackend, ApplicationStateTree> {
             .enable_iter("node_to_uri")
             .enable_iter("committee_selection_beacon")
             .enable_iter("committee_selection_beacon_non_revealing_node")
+            .enable_iter("mints")
             .enable_iter("withdraws");
 
         #[cfg(debug_assertions)]

--- a/core/e2e/tests/eth.rs
+++ b/core/e2e/tests/eth.rs
@@ -20,7 +20,7 @@ async fn e2e_eth_client_approve_revoke() {
     let chain_id = 1337;
     let mut swarm = Swarm::builder()
         .with_directory(temp_dir.path().to_path_buf().try_into().unwrap())
-        .with_min_port(10000)
+        .with_min_port(20000)
         .with_num_nodes(4)
         .with_chain_id(chain_id)
         .persistence(true)

--- a/core/interfaces/src/application.rs
+++ b/core/interfaces/src/application.rs
@@ -246,8 +246,11 @@ pub trait SyncQueryRunnerInterface: Clone + Send + Sync + 'static {
     // Returns whether the genesis block has been applied.
     fn has_genesis(&self) -> bool;
 
-    /// Returns a list of withdraws
+    /// Returns a list of withdraws.
     fn get_withdraws(&self, paging: WithdrawPagingParams) -> Vec<WithdrawInfoWithId>;
+
+    /// Returns true if the mint transaction for the provided tx hash was ordered.
+    fn has_minted(&self, tx_hash: [u8; 32]) -> bool;
 }
 
 #[derive(Clone, Debug)]

--- a/core/rpc/src/api/flk.rs
+++ b/core/rpc/src/api/flk.rs
@@ -227,6 +227,9 @@ pub trait FleekApi {
         paging: WithdrawPagingParams,
     ) -> RpcResult<Vec<WithdrawInfoWithId>>;
 
+    #[method(name = "has_minted")]
+    async fn has_minted(&self, tx_hash: [u8; 32]) -> RpcResult<bool>;
+
     #[subscription(name = "subscribe", item = Event)]
     async fn handle_subscription(&self, event_type: Option<EventType>) -> SubscriptionResult;
 }

--- a/core/rpc/src/logic/flk_impl.rs
+++ b/core/rpc/src/logic/flk_impl.rs
@@ -476,6 +476,10 @@ impl<C: NodeComponents> FleekApiServer for FleekApi<C> {
         Ok(self.data.query_runner(epoch).await?.get_withdraws(paging))
     }
 
+    async fn has_minted(&self, tx_hash: [u8; 32]) -> RpcResult<bool> {
+        Ok(self.data.query_runner(None).await?.has_minted(tx_hash))
+    }
+
     async fn handle_subscription(
         &self,
         pending: PendingSubscriptionSink,

--- a/core/types/src/application.rs
+++ b/core/types/src/application.rs
@@ -227,3 +227,12 @@ pub struct WithdrawInfoWithId {
     pub id: u64,
     pub info: WithdrawInfo,
 }
+
+#[derive(Debug, Hash, PartialEq, Serialize, Deserialize, Clone, schemars::JsonSchema)]
+pub struct MintInfo {
+    pub amount: HpUfixed<18>,
+    pub token: Tokens,
+    pub receiving_address: EthAddress,
+    pub eth_tx_hash: [u8; 32],
+    pub block_number: u64,
+}

--- a/core/types/src/response.rs
+++ b/core/types/src/response.rs
@@ -165,6 +165,7 @@ pub enum ExecutionError {
     TooManyMeasurements,
     TooManyUpdates,
     TooManyUpdatesForContent,
+    AlreadyMinted,
     // approve and revoke client key error types
     InvalidClientKeyLength,
     DuplicateClientKey,

--- a/core/types/src/transaction.rs
+++ b/core/types/src/transaction.rs
@@ -366,6 +366,10 @@ pub enum UpdateMethod {
         token: Tokens,
         /// The address to recieve these tokens on the network
         receiving_address: EthAddress,
+        /// The transaction hash from the deposit transaction send to the bridge contract.
+        eth_tx_hash: [u8; 32],
+        /// The block number from the deposit transaction send to the bridge contract.
+        block_number: u64,
     },
     /// Submit of PoC from the bridge on the L2 to get the tokens in network
     Deposit {
@@ -551,13 +555,17 @@ impl ToDigest for UpdatePayload {
                 amount,
                 token,
                 receiving_address,
+                eth_tx_hash,
+                block_number,
             } => {
                 transcript_builder = transcript_builder
                     .with("transaction_name", &"mint")
                     .with_prefix("input".to_owned())
                     .with("amount", &HpUfixedWrapper(amount.clone()))
                     .with("token", token)
-                    .with("receiving_address", &receiving_address.0);
+                    .with("receiving_address", &receiving_address.0)
+                    .with("eth_tx_hash", eth_tx_hash)
+                    .with("block_number", block_number);
             },
             UpdateMethod::Transfer { amount, token, to } => {
                 transcript_builder = transcript_builder


### PR DESCRIPTION
This adds mints to a state table, adds a method to query the table to the query runner, and also adds an rpc endpoint for it. This is needed for the bridge.