### PR TITLE
chore(application): don't clear withdraws after epoch change

### DIFF
--- a/core/application/src/state/executor/epoch_change.rs
+++ b/core/application/src/state/executor/epoch_change.rs
@@ -676,11 +676,6 @@ impl<B: Backend> StateExecutor<B> {
         // Clear executed digests.
         self.executed_digests.clear();
 
-        // Clear withdraws
-        self.withdraws.clear();
-        self.metadata
-            .set(Metadata::WithdrawId, Value::WithdrawId(0));
-
         self.committee_info.set(epoch, current_committee);
         // Get new committee
         let new_committee = self.choose_new_committee(beacons);


### PR DESCRIPTION
We will no longer clear the withdraws table after an epoch change and also don't reset the withdraw id. This way the bridge doesn't have to rely on the archiver. We can garbage collect the withdraws table using the `ClearWithdraws` transaction.