### PR TITLE
chore(fleek-crypto): remove expects from signature verification

### DIFF
--- a/lib/fleek-crypto/src/address.rs
+++ b/lib/fleek-crypto/src/address.rs
@@ -42,8 +42,10 @@ impl Serialize for EthAddress {
 
 impl EthAddress {
     pub fn verify(&self, signature: &AccountOwnerSignature, digest: &[u8]) -> bool {
-        let signature: Secp256k1RecoverableSignature =
-            signature.try_into().expect("invalid signature");
+        let signature: Result<Secp256k1RecoverableSignature, _> = signature.try_into();
+        let Ok(signature) = signature else {
+            return false;
+        };
         match signature.recover_with_hash::<Keccak256>(digest) {
             Ok(public_key) => {
                 if public_key

--- a/lib/fleek-crypto/src/transaction.rs
+++ b/lib/fleek-crypto/src/transaction.rs
@@ -60,13 +60,13 @@ impl TransactionSender {
     pub fn verify(&self, signature: TransactionSignature, digest: &[u8; 32]) -> bool {
         match (self, signature) {
             (TransactionSender::NodeConsensus(pk), TransactionSignature::NodeConsensus(sig)) => {
-                pk.verify(&sig, digest).expect("invalid signature")
+                pk.verify(&sig, digest).unwrap_or(false)
             },
             (TransactionSender::AccountOwner(pk), TransactionSignature::AccountOwner(sig)) => {
                 pk.verify(&sig, digest)
             },
             (TransactionSender::NodeMain(pk), TransactionSignature::NodeMain(sig)) => {
-                pk.verify(&sig, digest).expect("invalid signature")
+                pk.verify(&sig, digest).unwrap_or(false)
             },
             _ => false,
         }


### PR DESCRIPTION
Instead of panicking when the signature is invalid, we want to simply return false. 