### PR TITLE
fix(application): reset era on epoch change

### DIFF
--- a/core/application/src/state/executor/epoch_change.rs
+++ b/core/application/src/state/executor/epoch_change.rs
@@ -96,9 +96,6 @@ impl<B: Backend> StateExecutor<B> {
             // Start the committee beacon commit phase.
             self.set_committee_selection_beacon_commit_phase(epoch, 0);
 
-            // Reset the epoch era.
-            self.metadata.set(Metadata::EpochEra, Value::EpochEra(0));
-
             // Return success.
             TransactionResponse::Success(ExecutionData::None)
         } else {
@@ -670,6 +667,9 @@ impl<B: Backend> StateExecutor<B> {
 
         // Save new epoch to metadata.
         self.metadata.set(Metadata::Epoch, Value::Epoch(epoch));
+
+        // Reset the epoch era.
+        self.metadata.set(Metadata::EpochEra, Value::EpochEra(0));
     }
 
     fn choose_new_committee(


### PR DESCRIPTION
Instead of resetting the era when the commit phase starts, we have to reset the era, once the epoch change is completed. Otherwise the consensus will be restarted twice in a row. Once for the era reset, and once for the epoch change.